### PR TITLE
refactor!: errors are no longer wrapped with method to set errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Assuming the `*azfunc.Context` is bound to the name `ctx`:
     * `ctx.Log().Info()` for info level logs.
     * `ctx.Log.Error()` for error level logs.
 * `ctx.Binding("<binding-name>")` - Provides access to the binding by name. If the binding it hasn't been provided together with the function at registration, it will created (will work as long as a binding with that same name is defined in the functions `function.json`)
-* `ctx.Err()` - Gets the error set to the context.
+* `ctx.Err()` - Get the error set to the context.
 * `ctx.SetError(err)` - Set an error to the context. This will signal to the underlying host that an error has occured and the execution will count as a failure. Use this followed by a `return` in the provided function to represent an "unrecoverable" error and exit early.
 
 ##### Error handling

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Assuming the `*azfunc.Context` is bound to the name `ctx`:
     * `ctx.Log().Info()` for info level logs.
     * `ctx.Log.Error()` for error level logs.
 * `ctx.Binding("<binding-name>")` - Provides access to the binding by name. If the binding it hasn't been provided together with the function at registration, it will created (will work as long as a binding with that same name is defined in the functions `function.json`)
-* `ctx.Err()` - Gets the error (mulitple errors if they are wrapped) of the context.
-* `ctx.SetError(err)` - Set an error to the context. This will signal to the underlying host that an error has occured and the execution will be deemed a failure. Use this followed by a `return` in the provided function to represent an "unrecoverable" error and exit early.
+* `ctx.Err()` - Gets the error set to the context.
+* `ctx.SetError(err)` - Set an error to the context. This will signal to the underlying host that an error has occured and the execution will count as a failure. Use this followed by a `return` in the provided function to represent an "unrecoverable" error and exit early.
 
 ##### Error handling
 
@@ -242,8 +242,10 @@ An Azure Function can have one and only one trigger. This module provides a coup
 The following triggers are supported:
 
 * `HTTP`
-* `Base`
-* `Queue` (alias for `Base`, to provide clarity and intention of the trigger)
+* `Timer`
+* `Queue` (alias for `Base`)
+* `Base` - Base trigger. Works with most incoming triggers from the function host.
+
 
 Custom defined trigger types can be used as long as they satisfy the `Triggerable` interface:
 

--- a/function.go
+++ b/function.go
@@ -75,7 +75,7 @@ func (c Context) Log() logger {
 	return c.log
 }
 
-// Err returns the errors set to the Context.
+// Err returns the error set to the Context.
 func (c Context) Err() error {
 	return c.err
 }

--- a/function.go
+++ b/function.go
@@ -1,8 +1,6 @@
 package azfunc
 
 import (
-	"fmt"
-
 	"github.com/KarlGW/azfunc/bindings"
 	"github.com/KarlGW/azfunc/triggers"
 )
@@ -68,7 +66,7 @@ type Context struct {
 	// clients contains clients defined by the user. It is up to the
 	// user to perform type assertion to handle these services.
 	clients clients
-	// err contains error (wrapped if multiple).
+	// err contains error set to the Context.
 	err error
 }
 
@@ -77,18 +75,14 @@ func (c Context) Log() logger {
 	return c.log
 }
 
-// Err returns the errors (wrapped if multiple) set to the Context.
+// Err returns the errors set to the Context.
 func (c Context) Err() error {
 	return c.err
 }
 
 // SetError sets an error to the Context.
 func (c *Context) SetError(err error) {
-	if c.err == nil {
-		c.err = err
-		return
-	}
-	c.err = fmt.Errorf("%w", err)
+	c.err = err
 }
 
 // Services returns the services set in the Context.


### PR DESCRIPTION
This pull request simplifies the method `SetError` on `Context`. Errors are now longer wrapped, the error overwrites any other error set to the `Context.

All necessary wrapping should be performed by the user.