### PR TITLE
feat!: add event grid trigger and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Triggered by a message to an Azure Service Bus queue or topic subscription.
 func(ctx *azfunc.Context, trigger *triggers.ServiceBus)
 ```
 
+**[Event Grid trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#EventGrid)**
+
+Triggered by an event to an Azure Event Grid topic subscription.
+
+```go
+func(ctx *azfunc.Context, trigger *triggers.EventGrid)
+```
+
 **[Base trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#Base)**
 
 Base trigger is a base that can be used for all not yet supported triggers. The data it contains

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ The triggers is the triggering event and the data it contains, and the context c
 **[HTTP trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#HTTP)**
 
 Triggered by an incoming HTTP event. The trigger contains the HTTP data (headers, url, query, params and body).
-Name on the trigger in `function.json` must be `req`.
 
 ```go
 func(ctx *azfunc.Context, trigger *triggers.HTTP)
@@ -70,7 +69,6 @@ func(ctx *azfunc.Context, trigger *triggers.HTTP)
 **[Timer trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#Timer)**
 
 Triggered by a schedule. The trigger contains the timer data (next and last run etc).
-Name on the trigger in `function.json` must be `timer`.
 
 ```go
 func(ctx *azfunc.Context, trigger *triggers.Timer)

--- a/bindings/queue.go
+++ b/bindings/queue.go
@@ -2,13 +2,13 @@ package bindings
 
 import "github.com/KarlGW/azfunc/data"
 
-// Queue represents a queue storage output binding.
+// Queue represents a Queue Storage output binding.
 type Queue struct {
 	name string
 	data data.Raw
 }
 
-// QueueOptions contains options for a Queue output binding.
+// QueueOptions contains options for a Queue Storage output binding.
 type QueueOptions struct {
 	// Name sets the name of the binding.
 	Name string
@@ -16,7 +16,7 @@ type QueueOptions struct {
 	Data data.Raw
 }
 
-// QueueOption is a function that sets options on a Queue output binding.
+// QueueOption is a function that sets options on a Queue Storage output binding.
 type QueueOption func(o *QueueOptions)
 
 // Data returns the data of the binding.

--- a/triggers/base.go
+++ b/triggers/base.go
@@ -11,7 +11,7 @@ import (
 // triggers that are not HTTP triggers share the same data structure.
 type Base struct {
 	Metadata map[string]any
-	data     data.Raw
+	Data     data.Raw
 }
 
 // BaseOptions contains options for a Base trigger.
@@ -23,12 +23,7 @@ type BaseOption func(o *BaseOptions)
 // Parse the data of the Base trigger into the provided
 // value.
 func (t Base) Parse(v any) error {
-	return json.Unmarshal(t.data, &v)
-}
-
-// Data returns the data of the Base trigger.
-func (t Base) Data() data.Raw {
-	return t.data
+	return json.Unmarshal(t.Data, &v)
 }
 
 // NewBase creates an returns a Base trigger from the provided
@@ -51,7 +46,7 @@ func NewBase(r *http.Request, name string, options ...BaseOption) (*Base, error)
 	}
 
 	return &Base{
-		data:     d,
+		Data:     d,
 		Metadata: t.Metadata,
 	}, nil
 }

--- a/triggers/base.go
+++ b/triggers/base.go
@@ -20,13 +20,13 @@ type BaseOptions struct{}
 // BaseOption is a function that sets options on a Base trigger.
 type BaseOption func(o *BaseOptions)
 
-// Parse the Raw data of the Base trigger into the provided
+// Parse the data of the Base trigger into the provided
 // value.
 func (t Base) Parse(v any) error {
 	return json.Unmarshal(t.data, &v)
 }
 
-// Data returns the Raw data of the Base trigger.
+// Data returns the data of the Base trigger.
 func (t Base) Data() data.Raw {
 	return t.data
 }

--- a/triggers/base_test.go
+++ b/triggers/base_test.go
@@ -34,7 +34,7 @@ func TestNewBase(t *testing.T) {
 				name: "base",
 			},
 			want: &Base{
-				data: data.Raw(`{"message":"hello","number":2}`),
+				Data: data.Raw(`{"message":"hello","number":2}`),
 				Metadata: map[string]any{
 					"sys": map[string]any{
 						"MethodName": "helloBase",

--- a/triggers/event_grid.go
+++ b/triggers/event_grid.go
@@ -64,7 +64,7 @@ func (t EventGrid) Parse(v any) error {
 }
 
 // NewEventGrid creates and returns an Event Grid trigger from the provided
-// *http.Request. The
+// *http.Request.
 func NewEventGrid(r *http.Request, name string, options ...EventGridOption) (*EventGrid, error) {
 	opts := EventGridOptions{}
 	for _, option := range options {

--- a/triggers/event_grid.go
+++ b/triggers/event_grid.go
@@ -46,9 +46,7 @@ type EventGrid struct {
 }
 
 // EventGridOptions contains options for an Event Grid trigger.
-type EventGridOptions struct {
-	Schema EventGridSchema
-}
+type EventGridOptions struct{}
 
 // EventGridOption is a function that sets options on an Event Grid
 // trigger.
@@ -68,9 +66,7 @@ func (t EventGrid) Parse(v any) error {
 // NewEventGrid creates and returns an Event Grid trigger from the provided
 // *http.Request. The
 func NewEventGrid(r *http.Request, name string, options ...EventGridOption) (*EventGrid, error) {
-	opts := EventGridOptions{
-		Schema: EventGridSchemaCloudEvents,
-	}
+	opts := EventGridOptions{}
 	for _, option := range options {
 		option(&opts)
 	}

--- a/triggers/event_grid.go
+++ b/triggers/event_grid.go
@@ -88,7 +88,7 @@ func NewEventGrid(r *http.Request, name string, options ...EventGridOption) (*Ev
 		topic, typ = d.Source, d.Type
 		eventTime = d.Time
 		schema = EventGridSchemaCloudEvents
-	} else if len(d.MetadataVersion) > 0 {
+	} else if len(d.EventType) > 0 {
 		topic, typ = d.Topic, d.EventType
 		eventTime = d.EventTime
 		schema = EventGridSchemaEventGrid

--- a/triggers/event_grid.go
+++ b/triggers/event_grid.go
@@ -1,0 +1,127 @@
+package triggers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/KarlGW/azfunc/data"
+)
+
+// EventGridSchema is the type of schema that the Event Grid trigger
+// is using.
+type EventGridSchema int
+
+const (
+	// EventGridSchemaCloudEvents is the CloudEvents schema.
+	EventGridSchemaCloudEvents EventGridSchema = iota
+	// EventGridSchemaEventGrid is the Event Grid schema.
+	EventGridSchemaEventGrid
+)
+
+// EventGrid represents an Event Grid trigger. It handles both
+// Cloud Events and Event Grid events. Cloud events is the recommended
+// schema to use, and thus those property names are used.
+// The Even Grid schema properties 'Topic', 'EventType' and 'EventTime'
+// is set to the properties 'Source', 'Type' and 'Time' respectively.
+type EventGrid struct {
+	Time     time.Time
+	Metadata EventGridMetadata
+	ID       string
+	Source   string
+	Subject  string
+	Type     string
+	Data     data.Raw
+	Schema   EventGridSchema
+}
+
+// EventGridOptions contains options for an Event Grid trigger.
+type EventGridOptions struct {
+	Schema EventGridSchema
+}
+
+// EventGridOption is a function that sets options on an Event Grid
+// trigger.
+type EventGridOption func(o *EventGridOptions)
+
+// EventGridMetadata represents the metadata for an Event Grid trigger.
+type EventGridMetadata struct {
+	Metadata
+	Data data.Raw `json:"data"`
+}
+
+// Parse the data from the Event Grid trigger into the provided value.
+func (t EventGrid) Parse(v any) error {
+	return json.Unmarshal(t.Data, &v)
+}
+
+// NewEventGrid creates and returns an Event Grid trigger from the provided
+// *http.Request. The
+func NewEventGrid(r *http.Request, name string, options ...EventGridOption) (*EventGrid, error) {
+	opts := EventGridOptions{
+		Schema: EventGridSchemaCloudEvents,
+	}
+	for _, option := range options {
+		option(&opts)
+	}
+
+	var t eventGridTrigger
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		return nil, ErrTriggerPayloadMalformed
+	}
+
+	d, ok := t.Data[name]
+	if !ok {
+		return nil, ErrTriggerNameIncorrect
+	}
+
+	var source, typ string
+	var eventTime time.Time
+	var schema EventGridSchema
+	if len(d.SpecVersion) > 0 {
+		source, typ = d.Source, d.Type
+		eventTime = d.Time
+		schema = EventGridSchemaCloudEvents
+	} else if len(d.MetadataVersion) > 0 {
+		source, typ = d.Topic, d.EventType
+		eventTime = d.EventTime
+		schema = EventGridSchemaEventGrid
+	} else {
+		return nil, ErrTriggerPayloadMalformed
+	}
+
+	return &EventGrid{
+		ID:       d.ID,
+		Source:   source,
+		Subject:  d.Subject,
+		Type:     typ,
+		Time:     eventTime,
+		Data:     d.Data,
+		Metadata: t.Metadata,
+		Schema:   schema,
+	}, nil
+}
+
+// eventGridTrigger is the incoming request from the Function host.
+type eventGridTrigger struct {
+	Data     map[string]event
+	Metadata EventGridMetadata
+}
+
+// event is the incoming event from the Function host. It contains
+// all the properties that are included in both the cloud events
+// schema and the event grid schema.
+type event struct {
+	ID              string    `json:"id"`
+	Source          string    `json:"source"`
+	Topic           string    `json:"topic"`
+	Subject         string    `json:"subject"`
+	Type            string    `json:"type"`
+	EventType       string    `json:"eventType"`
+	Time            time.Time `json:"time"`
+	EventTime       time.Time `json:"eventTime"`
+	SpecVersion     string    `json:"specversion"`
+	DataVersion     string    `json:"dataVersion"`
+	MetadataVersion string    `json:"metadataVersion"`
+	Data            data.Raw  `json:"data"`
+}

--- a/triggers/event_grid.go
+++ b/triggers/event_grid.go
@@ -31,8 +31,8 @@ func (s EventGridSchema) String() string {
 }
 
 // EventGrid represents an Event Grid trigger. It handles both
-// Cloud Events and Event Grid events. For both types of events
-// the 'Topic' are used to describe the source of the event. This
+// Cloud Events and Event Grid events. For both types of events,
+// the 'Topic' is used to describe the source of the event. This
 // to match the nomenclature of the Event Grid service.
 type EventGrid struct {
 	Time     time.Time

--- a/triggers/event_grid_test.go
+++ b/triggers/event_grid_test.go
@@ -1,0 +1,256 @@
+package triggers
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/KarlGW/azfunc/data"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewEventGrid(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input struct {
+			req     *http.Request
+			name    string
+			options []EventGridOption
+		}
+		want    *EventGrid
+		wantErr error
+	}{
+		{
+			name: "NewEventGrid - cloud event",
+			input: struct {
+				req     *http.Request
+				name    string
+				options []EventGridOption
+			}{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewBuffer(eventGridCloudEventRequest1)),
+				},
+				name: "event",
+			},
+			want: &EventGrid{
+				ID:      "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+				Source:  "source",
+				Subject: "subject",
+				Type:    "created",
+				Time:    _testEventGridTime1,
+				Data:    data.Raw(`{"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"}`),
+				Schema:  EventGridSchemaCloudEvents,
+				Metadata: EventGridMetadata{
+					Data: data.Raw(`{"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"}`),
+					Metadata: Metadata{
+						Sys: MetadataSys{
+							MethodName: "testevent",
+							UTCNow:     _testEventGridTime1,
+							RandGuid:   "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "NewEventGrid - event grid",
+			input: struct {
+				req     *http.Request
+				name    string
+				options []EventGridOption
+			}{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewBuffer(eventGridEventRequest1)),
+				},
+				name: "event",
+			},
+			want: &EventGrid{
+				ID:      "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+				Source:  "source",
+				Subject: "subject",
+				Type:    "created",
+				Time:    _testEventGridTime1,
+				Data:    data.Raw(`{"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"}`),
+				Schema:  EventGridSchemaEventGrid,
+				Metadata: EventGridMetadata{
+					Data: data.Raw(`{"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"}`),
+					Metadata: Metadata{
+						Sys: MetadataSys{
+							MethodName: "testevent",
+							UTCNow:     _testEventGridTime1,
+							RandGuid:   "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotErr := NewEventGrid(test.input.req, test.input.name, test.input.options...)
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("NewEventGrid() = unexpected result (-want +got)\n%s\n", diff)
+			}
+
+			if diff := cmp.Diff(test.wantErr, gotErr); diff != "" {
+				t.Errorf("NewEventGrid() = unexpected error (-want +got)\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestEventGrid_Parse(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input struct {
+			req     *http.Request
+			name    string
+			options []EventGridOption
+		}
+		want    eventGridTest
+		wantErr error
+	}{
+		{
+			name: "Parse",
+			input: struct {
+				req     *http.Request
+				name    string
+				options []EventGridOption
+			}{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewBuffer(eventGridCloudEventRequest1)),
+				},
+				name: "event",
+			},
+			want: eventGridTest{
+				ID:   "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+				Name: "test",
+			},
+		},
+		{
+			name: "Parse - pretty JSON",
+			input: struct {
+				req     *http.Request
+				name    string
+				options []EventGridOption
+			}{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewBuffer(eventGridCloudEventRequest2)),
+				},
+				name: "event",
+			},
+			want: eventGridTest{
+				ID:   "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+				Name: "test",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			trigger, err := NewEventGrid(test.input.req, test.input.name, test.input.options...)
+			if err != nil {
+				t.Fatalf("NewEventGrid() = unexpected error: %v", err)
+			}
+
+			var got eventGridTest
+			gotErr := trigger.Parse(&got)
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Parse() = unexpected result (-want +got)\n%s\n", diff)
+			}
+
+			if test.wantErr == nil && gotErr != nil {
+				t.Errorf("Parse() = unexpected error: %v\n", gotErr)
+			}
+
+		})
+	}
+}
+
+var eventGridCloudEventRequest1 = []byte(`{
+	"Data": {
+	  "event": {
+		"id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+		"source": "source",
+		"specversion": "1.0",
+		"type": "created",
+		"subject": "subject",
+		"time": "2023-10-12T20:13:49.640002Z",
+		"data": {"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"}
+	  }
+	},
+	"Metadata": {
+	  "data": {"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"},
+	  "sys": {
+		"MethodName": "testevent",
+		"UtcNow": "2023-10-12T20:13:49.640002Z",
+		"RandGuid": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741"
+	  }
+	}
+  }
+`)
+
+var eventGridCloudEventRequest2 = []byte(`{
+	"Data": {
+	  "event": {
+		"id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+		"source": "source",
+		"specversion": "1.0",
+		"type": "created",
+		"subject": "subject",
+		"time": "2023-10-12T20:13:49.640002Z",
+		"data": {
+		  "id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+		  "name": "test"
+		}
+	  }
+	},
+	"Metadata": {
+	  "data": {
+		"id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+		"name": "test"
+	  },
+	  "sys": {
+		"MethodName": "testevent",
+		"UtcNow": "2023-10-12T20:13:49.640002Z",
+		"RandGuid": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741"
+	  }
+	}
+  }
+`)
+
+var eventGridEventRequest1 = []byte(`{
+	"Data": {
+	  "event": {
+		"id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+		"topic": "source",
+		"subject": "subject",
+		"eventType": "created",
+		"dataVersion": "1",
+		"metadataVersion": "1",
+		"eventTime": "2023-10-12T20:13:49.640002Z",
+		"data": {"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"}
+	  }
+	},
+	"Metadata": {
+	  "data": {"id":"4e773554-f6b7-4ea2-b07d-4c5fd5aba741","name":"test"},
+	  "sys": {
+		"MethodName": "testevent",
+		"UtcNow": "2023-10-12T20:13:49.640002Z",
+		"RandGuid": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741"
+	  }
+	}
+  }
+`)
+
+var _testEventGridTime1, _ = time.Parse("2006-01-02T15:04:05.999999Z", "2023-10-12T20:13:49.640002Z")
+
+type eventGridTest struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}

--- a/triggers/event_grid_test.go
+++ b/triggers/event_grid_test.go
@@ -36,7 +36,7 @@ func TestNewEventGrid(t *testing.T) {
 			},
 			want: &EventGrid{
 				ID:      "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
-				Source:  "source",
+				Topic:   "topic",
 				Subject: "subject",
 				Type:    "created",
 				Time:    _testEventGridTime1,
@@ -68,7 +68,7 @@ func TestNewEventGrid(t *testing.T) {
 			},
 			want: &EventGrid{
 				ID:      "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
-				Source:  "source",
+				Topic:   "topic",
 				Subject: "subject",
 				Type:    "created",
 				Time:    _testEventGridTime1,
@@ -172,11 +172,40 @@ func TestEventGrid_Parse(t *testing.T) {
 	}
 }
 
+func TestEventGridSchema_String(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input EventGridSchema
+		want  string
+	}{
+		{
+			name:  "cloud events",
+			input: EventGridSchemaCloudEvents,
+			want:  "CloudEvents",
+		},
+		{
+			name:  "event grid",
+			input: EventGridSchemaEventGrid,
+			want:  "EventGrid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.String()
+
+			if test.want != got {
+				t.Errorf("String() = unexpected result, want: %s, got: %s\n", test.want, got)
+			}
+		})
+	}
+}
+
 var eventGridCloudEventRequest1 = []byte(`{
 	"Data": {
 	  "event": {
 		"id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
-		"source": "source",
+		"source": "topic",
 		"specversion": "1.0",
 		"type": "created",
 		"subject": "subject",
@@ -199,7 +228,7 @@ var eventGridCloudEventRequest2 = []byte(`{
 	"Data": {
 	  "event": {
 		"id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
-		"source": "source",
+		"source": "topic",
 		"specversion": "1.0",
 		"type": "created",
 		"subject": "subject",
@@ -228,7 +257,7 @@ var eventGridEventRequest1 = []byte(`{
 	"Data": {
 	  "event": {
 		"id": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
-		"topic": "source",
+		"topic": "topic",
 		"subject": "subject",
 		"eventType": "created",
 		"dataVersion": "1",

--- a/triggers/http.go
+++ b/triggers/http.go
@@ -83,11 +83,6 @@ func (t HTTP) Parse(v any) error {
 	return json.Unmarshal(t.Body, &v)
 }
 
-// Data returns the data (body) of the HTTP trigger.
-func (t HTTP) Data() data.Raw {
-	return t.Body
-}
-
 // Form parses the HTTP trigger for form data sent with Content-Type
 // application/x-www-form-urlencoded and returns it as url.Values.
 func (t HTTP) Form() (url.Values, error) {

--- a/triggers/http.go
+++ b/triggers/http.go
@@ -31,7 +31,7 @@ type HTTP struct {
 	Headers    http.Header
 	Params     map[string]string
 	Query      map[string]string
-	URL        string
+	URL        string `json:"Url"`
 	Method     string
 	Body       data.Raw
 	Metadata   HTTPMetadata
@@ -83,7 +83,7 @@ func (t HTTP) Parse(v any) error {
 	return json.Unmarshal(t.Body, &v)
 }
 
-// Data returns the Raw data of the HTTP trigger.
+// Data returns the data (body) of the HTTP trigger.
 func (t HTTP) Data() data.Raw {
 	return t.Body
 }
@@ -138,10 +138,13 @@ func (t HTTP) MultipartForm(maxMemory int64) (*multipart.Form, error) {
 }
 
 // NewHTTP creates and returns an HTTP trigger from the provided
-// *http.Request. The name on the trigger in function.json must
-// be "req".
+// *http.Request. By default it will use the name "req" for the
+// trigger. This can be overridden with providing a name
+// in the options.
 func NewHTTP(r *http.Request, options ...HTTPOption) (*HTTP, error) {
-	opts := HTTPOptions{}
+	opts := HTTPOptions{
+		Name: "req",
+	}
 	for _, option := range options {
 		option(&opts)
 	}
@@ -152,30 +155,17 @@ func NewHTTP(r *http.Request, options ...HTTPOption) (*HTTP, error) {
 	}
 	defer r.Body.Close()
 
-	return &HTTP{
-		URL:        t.Data.Req.URL,
-		Method:     t.Data.Req.Method,
-		Body:       t.Data.Req.Body,
-		Headers:    t.Data.Req.Headers,
-		Params:     t.Data.Req.Params,
-		Query:      t.Data.Req.Query,
-		Identities: t.Data.Req.Identities,
-		Metadata:   t.Metadata,
-	}, nil
+	d, ok := t.Data[opts.Name]
+	if !ok {
+		return nil, ErrTriggerNameIncorrect
+	}
+	d.Metadata = t.Metadata
+
+	return &d, nil
 }
 
 // httpTrigger is the incoming request from the Function host.
 type httpTrigger struct {
+	Data     map[string]HTTP
 	Metadata HTTPMetadata
-	Data     struct {
-		Req struct {
-			URL        string `json:"Url"`
-			Method     string
-			Body       data.Raw
-			Headers    http.Header
-			Params     map[string]string
-			Query      map[string]string
-			Identities []HTTPIdentity
-		} `json:"req"`
-	}
 }

--- a/triggers/http_test.go
+++ b/triggers/http_test.go
@@ -82,11 +82,73 @@ func TestNewHTTP(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "NewHTTP - with provided name",
+			input: struct {
+				req     *http.Request
+				options []HTTPOption
+			}{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewBuffer(httpRequest2)),
+				},
+				options: []HTTPOption{
+					func(o *HTTPOptions) {
+						o.Name = "custom"
+					},
+				},
+			},
+			want: &HTTP{
+				URL:    "http://localhost:7071/api/endpoint",
+				Method: http.MethodPost,
+				Body:   data.Raw(`{"message":"hello","number":2}`),
+				Headers: http.Header{
+					"Content-Type": {"application/json"},
+				},
+				Params: map[string]string{},
+				Query:  map[string]string{},
+				Identities: []HTTPIdentity{
+					{
+						AuthenticationType: "WebJobsAuthLevel",
+						IsAuthenticated:    true,
+						Actor:              nil,
+						BootstrapContext:   nil,
+						Claims: []HTTPIdentityClaims{
+							{
+								Issuer:         "LOCAL AUTHORITY",
+								OriginalIssuer: "LOCAL AUTHORITY",
+								Properties:     map[string]string{},
+								Type:           "http://schemas.microsoft.com/2017/07/functions/claims/authlevel",
+								Value:          "Admin",
+								ValueType:      "http://www.w3.org/2001/XMLSchema#string",
+							},
+						},
+						Label:         nil,
+						Name:          nil,
+						NameClaimType: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+						RoleClaimType: "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+					},
+				},
+				Metadata: HTTPMetadata{
+					Params: map[string]string{},
+					Query:  map[string]string{},
+					Headers: map[string]string{
+						"Content-Type": "application/json",
+					},
+					Metadata: Metadata{
+						Sys: MetadataSys{
+							MethodName: "helloHTTP",
+							UTCNow:     _testHTTPTime1,
+							RandGuid:   "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, gotErr := NewHTTP(test.input.req)
+			got, gotErr := NewHTTP(test.input.req, test.input.options...)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("NewHTTP() = unexpected result (-want +got)\n%s\n", diff)
@@ -228,6 +290,58 @@ func TestHTTP_MultipartForm(t *testing.T) {
 var httpRequest1 = []byte(`{
 	"Data": {
 	  "req": {
+		"Url": "http://localhost:7071/api/endpoint",
+		"Method": "POST",
+		"Body": "{\"message\":\"hello\",\"number\":2}",
+		"Params": {},
+		"Query": {},
+		"Headers": {
+		  "Content-Type": [
+			"application/json"
+		  ]
+		},
+		"Identities": [
+		  {
+			"AuthenticationType": "WebJobsAuthLevel",
+			"IsAuthenticated": true,
+			"Actor": null,
+			"BootstrapContext": null,
+			"Claims": [
+			  {
+				"Issuer": "LOCAL AUTHORITY",
+				"OriginalIssuer": "LOCAL AUTHORITY",
+				"Properties": {},
+				"Type": "http://schemas.microsoft.com/2017/07/functions/claims/authlevel",
+				"Value": "Admin",
+				"ValueType": "http://www.w3.org/2001/XMLSchema#string"
+			  }
+			],
+			"Label": null,
+			"Name": null,
+			"NameClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+			"RoleClaimType": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+		  }
+		]
+	  }
+	},
+	"Metadata": {
+	  "Params": {},
+	  "Query": {},
+	  "Headers": {
+		"Content-Type": "application/json"
+	  },
+	  "sys": {
+		"MethodName": "helloHTTP",
+		"UtcNow": "2023-10-12T20:13:49.640002Z",
+		"RandGuid": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741"
+	  }
+	}
+  }
+`)
+
+var httpRequest2 = []byte(`{
+	"Data": {
+	  "custom": {
 		"Url": "http://localhost:7071/api/endpoint",
 		"Method": "POST",
 		"Body": "{\"message\":\"hello\",\"number\":2}",

--- a/triggers/queue.go
+++ b/triggers/queue.go
@@ -12,7 +12,7 @@ import (
 // Queue represents a Queue Storage trigger.
 type Queue struct {
 	Metadata QueueMetadata
-	data     data.Raw
+	Data     data.Raw
 }
 
 // QueueOptions contains options for a Queue Storage trigger.
@@ -35,12 +35,7 @@ type QueueMetadata struct {
 // Parse the data of the Queue Storage trigger into the provided
 // value.
 func (t Queue) Parse(v any) error {
-	return json.Unmarshal(t.data, &v)
-}
-
-// Data returns the data of the Queue Storage trigger.
-func (t Queue) Data() data.Raw {
-	return t.data
+	return json.Unmarshal(t.Data, &v)
 }
 
 // NewQueue creates and returns a new Queue Storage trigger from the
@@ -66,7 +61,7 @@ func NewQueue(r *http.Request, name string, options ...QueueOption) (*Queue, err
 	t.Metadata.PopReceipt = strings.Trim(t.Metadata.PopReceipt, "\"")
 
 	return &Queue{
-		data:     d,
+		Data:     d,
 		Metadata: t.Metadata,
 	}, nil
 }

--- a/triggers/queue_test.go
+++ b/triggers/queue_test.go
@@ -35,7 +35,7 @@ func TestNewQueue(t *testing.T) {
 				name: "queue",
 			},
 			want: &Queue{
-				data: data.Raw(`{"message":"hello","number":2}`),
+				Data: data.Raw(`{"message":"hello","number":2}`),
 				Metadata: QueueMetadata{
 					DequeueCount:    "1",
 					ID:              "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",

--- a/triggers/service_bus.go
+++ b/triggers/service_bus.go
@@ -11,7 +11,7 @@ import (
 // ServiceBus represents a Service Bus trigger. It supports both
 // queues and topics with subscriptions.
 type ServiceBus struct {
-	data     data.Raw
+	Data     data.Raw
 	Metadata ServiceBusMetadata
 }
 
@@ -56,12 +56,7 @@ type ServiceBusMetadataClient struct {
 // Parse the data for the Service Bus trigger into the provided
 // value.
 func (t ServiceBus) Parse(v any) error {
-	return json.Unmarshal(t.data, &v)
-}
-
-// Data returns the data of the Service Bus trigger.
-func (t ServiceBus) Data() data.Raw {
-	return t.data
+	return json.Unmarshal(t.Data, &v)
 }
 
 // NewServiceBus creates and returns a new Service Bus trigger from the
@@ -88,7 +83,7 @@ func NewServiceBus(r *http.Request, name string, options ...ServiceBusOption) (*
 	t.Metadata.ContentType = strings.Trim(t.Metadata.ContentType, "\"")
 
 	return &ServiceBus{
-		data:     d,
+		Data:     d,
 		Metadata: t.Metadata,
 	}, nil
 }

--- a/triggers/service_bus_test.go
+++ b/triggers/service_bus_test.go
@@ -35,7 +35,7 @@ func TestNewServiceBus(t *testing.T) {
 				name: "queue",
 			},
 			want: &ServiceBus{
-				data: data.Raw(`{"message":"hello","number":2}`),
+				Data: data.Raw(`{"message":"hello","number":2}`),
 				Metadata: ServiceBusMetadata{
 					Client: ServiceBusMetadataClient{
 						FullyQualifiedNamespace: "namespace",

--- a/triggers/timer.go
+++ b/triggers/timer.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
-
-	"github.com/KarlGW/azfunc/data"
 )
 
 // Timer represent a Timer trigger.
@@ -36,20 +34,6 @@ type TimerScheduleStatus struct {
 	Last        time.Time
 	Next        time.Time
 	LastUpdated time.Time
-}
-
-// Parse together with Data satisfies the Triggerable interface. It
-// is a no-op method. A timer trigger contains no other data needed
-// to be parsed. Use the fields directly.
-func (t Timer) Parse(v any) error {
-	return nil
-}
-
-// Data together with Parse satisfies the Triggerable interface. It
-// is a no-op method. A timer trigger contains no other data needed
-// to be parsed. Use the fields directly.
-func (t Timer) Data() data.Raw {
-	return nil
 }
 
 // NewTimer creates and returns a Timer trigger from the provided

--- a/triggers/timer_test.go
+++ b/triggers/timer_test.go
@@ -50,11 +50,46 @@ func TestNewTimer(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "NewTimer - provided name",
+			input: struct {
+				req     *http.Request
+				options []TimerOption
+			}{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewBuffer(timerRequest2)),
+				},
+				options: []TimerOption{
+					func(o *TimerOptions) {
+						o.Name = "custom"
+					},
+				},
+			},
+			want: &Timer{
+				Schedule: TimerSchedule{
+					AdjustForDST: true,
+				},
+				ScheduleStatus: TimerScheduleStatus{
+					Last:        _testTimerTime1,
+					Next:        _testTimerTime1,
+					LastUpdated: _testTimerTime1,
+				},
+				IsPastDue: false,
+				Metadata: Metadata{
+					Sys: MetadataSys{
+						MethodName: "helloTimer",
+						UTCNow:     _testTimerTime1,
+						RandGuid:   "4e773554-f6b7-4ea2-b07d-4c5fd5aba741",
+					},
+				},
+			},
+			wantErr: nil,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, gotErr := NewTimer(test.input.req)
+			got, gotErr := NewTimer(test.input.req, test.input.options...)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("NewTimer() = unexpected result (-want +got)\n%s\n", diff)
@@ -70,6 +105,30 @@ func TestNewTimer(t *testing.T) {
 var timerRequest1 = []byte(`{
 	"Data": {
 	  "timer": {
+		"Schedule": {
+		  "AdjustForDST": true
+		},
+		"ScheduleStatus": {
+		  "Last": "2023-10-12T20:13:49.640002Z",
+		  "Next": "2023-10-12T20:13:49.640002Z",
+		  "LastUpdated": "2023-10-12T20:13:49.640002Z"
+		},
+		"IsPastDue": false
+	  }
+	},
+	"Metadata": {
+	  "sys": {
+		"MethodName": "helloTimer",
+		"UtcNow": "2023-10-12T20:13:49.640002Z",
+		"RandGuid": "4e773554-f6b7-4ea2-b07d-4c5fd5aba741"
+	  }
+	}
+  }
+`)
+
+var timerRequest2 = []byte(`{
+	"Data": {
+	  "custom": {
 		"Schedule": {
 		  "AdjustForDST": true
 		},


### PR DESCRIPTION
This pull request adds support for Event Grid triggers.

Additionally it introduces a breaking change in that it removed method `Data` from triggers and made the `data` field exported (renamed to `Data`). This is because the `Triggerable` interface from the `triggers` package has been removed, and no other code in the module relies on the interface in combination with the triggers being accessable from functions.