### PR TITLE
!feat: package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and from the Azure Function host when developing Azure Functions with Custom han
 * [Usage](#usage)
   * [Concepts](#concepts)
     * [Triggers (input bindings)](#triggers-input-bindings)
-    * [Output (output bindings)](#output-output-bindings)
+    * [Outputs (output bindings)](#outputs-output-bindings)
     * [Context](#context)
   * [Error handling](#error-handling)
 * [TODO](#todo)
@@ -72,13 +72,13 @@ package main
 
 import (
     "github.com/KarlGW/azfunc"
-    "github.com/KarlGW/azfunc/triggers"
+    "github.com/KarlGW/azfunc/trigger"
 )
 
 func main() {
     app := azfunc.NewFunctionApp()
 
-    app.AddFunction("hello-http", azfunc.HTTPTrigger(func(ctx *azfunc.Context, trigger *triggers.HTTP) error {
+    app.AddFunction("hello-http", azfunc.HTTPTrigger(func(ctx *azfunc.Context, trigger *trigger.HTTP) error {
         // Parse the incoming trigger body into the custom type.
         var t test
         if err := trigger.Parse(&t); err != nil {
@@ -104,14 +104,14 @@ type test struct {
 }
 ```
 
-More examples with different triggers and output can be found [here](./_examples/).
+More examples with different triggers and output bindings can be found [here](./_examples/).
 
 ## Usage
 
 The framework takes care of setting up the server and handlers, and you as a user register functions and bindings. Each function must have a corresponding `function.json` with binding specifications, in a folder named after the function. For more information about bindings, check out the [documentation](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-expressions-patterns).
 
-The triggers and bindings registered to
-the `FunctionApp` must match with the names of the bindings in this file, the exception being with HTTP triggers and bindings, `req` and `res` where this is handled without the names for convenience.
+The trigger and output bindings registered to
+the `FunctionApp` must match with the names of the bindings in this file, the exception being with HTTP trigger and output bindings, `req` and `res` where this is handled without the names for convenience.
 
 Creating this application structure can be done with ease with the help of the Function [Core tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local). In addition to scaffolding functions it can be used to run and test your functions locally.
 
@@ -120,78 +120,78 @@ An example on how to create a function with a HTTP trigger and a HTTP output bin
 
 ### Concepts
 
-When working with the `FunctionApp` there are some concepts to understand and work with. The `FunctionApp` represents the entire Function App, and it is to this structure the functions (with their triggers and output bindings) that should be run are registered to. Each function that is registered contains a `*azfunc.Context` and a [trigger](#triggers-input-bindings).
+When working with the `FunctionApp` there are some concepts to understand and work with. The `FunctionApp` represents the entire Function App, and it is to this structure the functions (with their trigger and output bindings) that should be run are registered to. Each function that is registered contains a `*azfunc.Context` and a [trigger](#triggers-input-bindings).
 
 The triggers is the triggering event and the data it contains, and the context contains output bindings (and writing to them), output error and logging.
 
 
 #### Triggers (input bindings)
 
-**[HTTP trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#HTTP)**
+**[HTTP trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/trigger#HTTP)**
 
 Triggered by an incoming HTTP event. The trigger contains the HTTP data (headers, url, query, params and body).
 
 ```go
-func(ctx *azfunc.Context, trigger *triggers.HTTP) error
+func(ctx *azfunc.Context, trigger *trigger.HTTP) error
 ```
 
-**[Timer trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#Timer)**
+**[Timer trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/trigger#Timer)**
 
 Triggered by a schedule. The trigger contains the timer data (next and last run etc).
 
 ```go
-func(ctx *azfunc.Context, trigger *triggers.Timer) error
+func(ctx *azfunc.Context, trigger *trigger.Timer) error
 ```
 
-**[Queue trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#Queue)**
+**[Queue trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/trigger#Queue)**
 
 Triggered by a message to an Azure Queue Storage queue.
 
 ```go
-func(ctx *azfunc.Context, trigger *triggers.Queue) error
+func(ctx *azfunc.Context, trigger *trigger.Queue) error
 ```
 
-**[Service Bus trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#ServiceBus)**
+**[Service Bus trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/trigger#ServiceBus)**
 
 Triggered by a message to an Azure Service Bus queue or topic subscription.
 
 ```go
-func(ctx *azfunc.Context, trigger *triggers.ServiceBus) error
+func(ctx *azfunc.Context, trigger *trigger.ServiceBus) error
 ```
 
-**[Event Grid trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#EventGrid)**
+**[Event Grid trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/trigger#EventGrid)**
 
 Triggered by an event to an Azure Event Grid topic subscription.
 
 ```go
-func(ctx *azfunc.Context, trigger *triggers.EventGrid) error
+func(ctx *azfunc.Context, trigger *trigger.EventGrid) error
 ```
 
-**[Generic trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/triggers#Generic)**
+**[Generic trigger](https://pkg.go.dev/github.com/KarlGW/azfunc/trigger#Generic)**
 
 Generic trigger is a generic trigger can be used for all not yet supported triggers. The data it contains
 needs to be parsed into a `struct` matching the expected incoming payload.
 
 ```go
-func(ctx *azfunc.Context, trigger *triggers.Generic) error
+func(ctx *azfunc.Context, trigger *trigger.Generic) error
 ```
 
 
-#### Output (output bindings)
+#### Outputs (output bindings)
 
-**[HTTP binding](https://pkg.go.dev/github.com/KarlGW/azfunc/bindings#HTTP)**
+**[HTTP output](https://pkg.go.dev/github.com/KarlGW/azfunc/output#HTTP)**
 
 Writes an HTTP response back to the caller (only works together with an **HTTP trigger**).
 
-**[Queue binding](https://pkg.go.dev/github.com/KarlGW/azfunc/bindings#Queue)**
+**[Queue output](https://pkg.go.dev/github.com/KarlGW/azfunc/output#Queue)**
 
 Writes a message to a queue in Azure Queue Storage.
 
-**[Service Bus binding](https://pkg.go.dev/github.com/KarlGW/azfunc/bindings#Queue)**
+**[Service Bus output](https://pkg.go.dev/github.com/KarlGW/azfunc/output#Queue)**
 
 Writes a message to a queue or topic subscription in Azure Service Bus.
 
-**[Generic binding](https://pkg.go.dev/github.com/KarlGW/azfunc/bindings#Generic)**
+**[Generic output](https://pkg.go.dev/github.com/KarlGW/azfunc/output#Generic)**
 
 Generic binding is a generic binding that can be used for all not yet supported bindings.
 
@@ -213,7 +213,7 @@ The functions provided to the `FunctionApp` returns an error.
 
 As an example: A function is triggered and run and encounters an error for one of it's calls. This error is deemed to be fatal and the function cannot carry on further. Thus we return the error.
 ```go
-func run(ctx *azfunc.Context, trigger *triggers.Queue) error {
+func run(ctx *azfunc.Context, trigger *trigger.Queue) error {
     if err := someFunc(); err != nil {
         // This error is fatal, return ut to signal to the function host
         // that a non-recoverable error has occured.
@@ -228,7 +228,7 @@ func run(ctx *azfunc.Context, trigger *triggers.Queue) error {
 An example of when an error is not regarded as fatal and not application breaking (like a malformed HTTP request), it can be handled like so:
 
 ```go
-func run(ctx *azfunc.Context, trigger *triggers.HTTP) error {
+func run(ctx *azfunc.Context, trigger *trigger.HTTP) error {
     var incoming IncomingRequest
     if err := trigger.Parse(&incoming); err != nil {
         // The incoming request body did not match the expected one,
@@ -247,7 +247,7 @@ func run(ctx *azfunc.Context, trigger *triggers.HTTP) error {
 Example with named return:
 
 ```go
-func run(ctx *azfunc.Context, trigger *triggers.HTTP) (err error) {
+func run(ctx *azfunc.Context, trigger *trigger.HTTP) (err error) {
     var incoming IncomingRequest
     if err = trigger.Parse(&incoming); err != nil {
         // The incoming request body did not match the expected one,
@@ -266,5 +266,6 @@ func run(ctx *azfunc.Context, trigger *triggers.HTTP) (err error) {
 ## TODO
 
 * Add more triggers and output bindings.
-* Add examples on using Managed Identities for triggers and output bindings (this is already supported).
+* Add examples on using Managed Identities for trigger and output bindings (this is already supported).
 * Add better documentation for `function.json` structure and relations between properties and functionality.
+* Add generation and/or validation of `host.json` and `function.json`.

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ func main() {
         }
         // Do something with t.
         // Create the response.
-        ctx.Output.HTTP().WriteHeader(http.StatusOK)
-        ctx.Output.HTTP().Header().Add("Content-Type", "application/json")
-        ctx.Output.HTTP().Write([]byte(`{"message":"received"}`))
+        ctx.Outputs().HTTP().WriteHeader(http.StatusOK)
+        ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
+        ctx.Outputs().HTTP().Write([]byte(`{"message":"received"}`))
         return nil
     }))
 
@@ -235,7 +235,7 @@ func run(ctx *azfunc.Context, trigger *trigger.HTTP) error {
         // this is equivalent of a HTTP 400 and should not signal to
         // the function host that it has failed, but still
         // stop further exection and return.
-        ctx.HTTP().WriteHeader(http.StatusBadRequest)
+        ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
         return nil
     }
     // ... ...
@@ -254,7 +254,7 @@ func run(ctx *azfunc.Context, trigger *trigger.HTTP) (err error) {
         // this is equivalent of a HTTP 400 and should not signal to
         // the function host that it has failed, but still
         // stop further exection and return.
-        ctx.HTTP().WriteHeader(http.StatusBadRequest)
+        ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
         return
     }
     // ... ...

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ func main() {
         }
         // Do something with t.
         // Create the response.
-        ctx.Outputs().HTTP().WriteHeader(http.StatusOK)
-        ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
-        ctx.Outputs().HTTP().Write([]byte(`{"message":"received"}`))
+        ctx.Outputs.HTTP().WriteHeader(http.StatusOK)
+        ctx.Outputs.HTTP().Header().Add("Content-Type", "application/json")
+        ctx.Outputs.HTTP().Write([]byte(`{"message":"received"}`))
         return nil
     }))
 
@@ -235,7 +235,7 @@ func run(ctx *azfunc.Context, trigger *trigger.HTTP) error {
         // this is equivalent of a HTTP 400 and should not signal to
         // the function host that it has failed, but still
         // stop further exection and return.
-        ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
+        ctx.Outputs.HTTP().WriteHeader(http.StatusBadRequest)
         return nil
     }
     // ... ...
@@ -254,7 +254,7 @@ func run(ctx *azfunc.Context, trigger *trigger.HTTP) (err error) {
         // this is equivalent of a HTTP 400 and should not signal to
         // the function host that it has failed, but still
         // stop further exection and return.
-        ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
+        ctx.Outputs.HTTP().WriteHeader(http.StatusBadRequest)
         return
     }
     // ... ...

--- a/_examples/http-trigger-queue-output/main.go
+++ b/_examples/http-trigger-queue-output/main.go
@@ -19,17 +19,17 @@ func main() {
 		if err := trigger.Parse(&t); err != nil {
 			// Send HTTP response back to the caller if parsing fails
 			// and exit the function.
-			ctx.Output.HTTP().WriteHeader(http.StatusBadRequest)
+			ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
 			return nil
 		}
 		// Log parsed t.
 		ctx.Log().Info("request received", "body", t)
 		// Create the HTTP response.
-		ctx.Output.HTTP().WriteHeader(http.StatusOK)
-		ctx.Output.HTTP().Header().Add("Content-Type", "application/json")
-		ctx.Output.HTTP().Write([]byte(`{"message":"request received"}`))
+		ctx.Outputs().HTTP().WriteHeader(http.StatusOK)
+		ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
+		ctx.Outputs().HTTP().Write([]byte(`{"message":"request received"}`))
 		// Create output to queue.
-		ctx.Output.Binding("queue").Write([]byte(`{"message":"request received"}`))
+		ctx.Outputs().Output("queue").Write([]byte(`{"message":"request received"}`))
 		return nil
 	}))
 

--- a/_examples/http-trigger-queue-output/main.go
+++ b/_examples/http-trigger-queue-output/main.go
@@ -29,7 +29,7 @@ func main() {
 		ctx.Outputs.HTTP().Header().Add("Content-Type", "application/json")
 		ctx.Outputs.HTTP().Write([]byte(`{"message":"request received"}`))
 		// Create output to queue.
-		ctx.Outputs.Output("queue").Write([]byte(`{"message":"request received"}`))
+		ctx.Outputs.Binding("queue").Write([]byte(`{"message":"request received"}`))
 		return nil
 	}))
 

--- a/_examples/http-trigger-queue-output/main.go
+++ b/_examples/http-trigger-queue-output/main.go
@@ -6,13 +6,13 @@ import (
 	"os"
 
 	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/triggers"
+	"github.com/KarlGW/azfunc/trigger"
 )
 
 func main() {
 	app := azfunc.NewFunctionApp(azfunc.WithLogger(azfunc.NewLogger()))
 
-	app.AddFunction("hello-http-queue", azfunc.HTTPTrigger(func(ctx *azfunc.Context, trigger *triggers.HTTP) error {
+	app.AddFunction("hello-http-queue", azfunc.HTTPTrigger(func(ctx *azfunc.Context, trigger *trigger.HTTP) error {
 		// Parse the incoming trigger body into the custom type.
 		// To get the raw data of the body, use trigger.Data instead.
 		var t test

--- a/_examples/http-trigger-queue-output/main.go
+++ b/_examples/http-trigger-queue-output/main.go
@@ -19,17 +19,17 @@ func main() {
 		if err := trigger.Parse(&t); err != nil {
 			// Send HTTP response back to the caller if parsing fails
 			// and exit the function.
-			ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
+			ctx.Outputs.HTTP().WriteHeader(http.StatusBadRequest)
 			return nil
 		}
 		// Log parsed t.
 		ctx.Log().Info("request received", "body", t)
 		// Create the HTTP response.
-		ctx.Outputs().HTTP().WriteHeader(http.StatusOK)
-		ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
-		ctx.Outputs().HTTP().Write([]byte(`{"message":"request received"}`))
+		ctx.Outputs.HTTP().WriteHeader(http.StatusOK)
+		ctx.Outputs.HTTP().Header().Add("Content-Type", "application/json")
+		ctx.Outputs.HTTP().Write([]byte(`{"message":"request received"}`))
 		// Create output to queue.
-		ctx.Outputs().Output("queue").Write([]byte(`{"message":"request received"}`))
+		ctx.Outputs.Output("queue").Write([]byte(`{"message":"request received"}`))
 		return nil
 	}))
 

--- a/_examples/http-trigger/main.go
+++ b/_examples/http-trigger/main.go
@@ -19,15 +19,15 @@ func main() {
 		if err := trigger.Parse(&t); err != nil {
 			// Send HTTP response back to the caller if parsing fails
 			// and exit the function.
-			ctx.Output.HTTP().WriteHeader(http.StatusBadRequest)
+			ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
 			return nil
 		}
 		// Log parsed t.
 		ctx.Log().Info("request received", "body", t)
 		// Create the HTTP response.
-		ctx.Output.HTTP().WriteHeader(http.StatusOK)
-		ctx.Output.HTTP().Header().Add("Content-Type", "application/json")
-		ctx.Output.HTTP().Write([]byte(`{"message":"request received"}`))
+		ctx.Outputs().HTTP().WriteHeader(http.StatusOK)
+		ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
+		ctx.Outputs().HTTP().Write([]byte(`{"message":"request received"}`))
 		return nil
 	}))
 

--- a/_examples/http-trigger/main.go
+++ b/_examples/http-trigger/main.go
@@ -19,15 +19,15 @@ func main() {
 		if err := trigger.Parse(&t); err != nil {
 			// Send HTTP response back to the caller if parsing fails
 			// and exit the function.
-			ctx.Outputs().HTTP().WriteHeader(http.StatusBadRequest)
+			ctx.Outputs.HTTP().WriteHeader(http.StatusBadRequest)
 			return nil
 		}
 		// Log parsed t.
 		ctx.Log().Info("request received", "body", t)
 		// Create the HTTP response.
-		ctx.Outputs().HTTP().WriteHeader(http.StatusOK)
-		ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
-		ctx.Outputs().HTTP().Write([]byte(`{"message":"request received"}`))
+		ctx.Outputs.HTTP().WriteHeader(http.StatusOK)
+		ctx.Outputs.HTTP().Header().Add("Content-Type", "application/json")
+		ctx.Outputs.HTTP().Write([]byte(`{"message":"request received"}`))
 		return nil
 	}))
 

--- a/_examples/http-trigger/main.go
+++ b/_examples/http-trigger/main.go
@@ -6,13 +6,13 @@ import (
 	"os"
 
 	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/triggers"
+	"github.com/KarlGW/azfunc/trigger"
 )
 
 func main() {
 	app := azfunc.NewFunctionApp(azfunc.WithLogger(azfunc.NewLogger()))
 
-	app.AddFunction("hello-http", azfunc.HTTPTrigger(func(ctx *azfunc.Context, trigger *triggers.HTTP) error {
+	app.AddFunction("hello-http", azfunc.HTTPTrigger(func(ctx *azfunc.Context, trigger *trigger.HTTP) error {
 		// Parse the incoming trigger body into the custom type.
 		// To get the raw data of the body, use trigger.Data instead.
 		var t test

--- a/_examples/queue-trigger/main.go
+++ b/_examples/queue-trigger/main.go
@@ -5,13 +5,13 @@ import (
 	"os"
 
 	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/triggers"
+	"github.com/KarlGW/azfunc/trigger"
 )
 
 func main() {
 	app := azfunc.NewFunctionApp(azfunc.WithLogger(azfunc.NewLogger()))
 
-	app.AddFunction("hello-queue", azfunc.QueueTrigger("queue", func(ctx *azfunc.Context, trigger *triggers.Queue) error {
+	app.AddFunction("hello-queue", azfunc.QueueTrigger("queue", func(ctx *azfunc.Context, trigger *trigger.Queue) error {
 		// Parse the incoming queue trigger body into the custom type.
 		// To get the raw data of the queue message, use trigger.Data instead.
 		var t test

--- a/_examples/queue-trigger/main.go
+++ b/_examples/queue-trigger/main.go
@@ -21,7 +21,7 @@ func main() {
 		// Log parsed t.
 		ctx.Log().Info("queue message received", "content", t)
 		// Create output to queue.
-		ctx.Output.Binding("outqueue").Write([]byte(`{"message":"message received"}`))
+		ctx.Outputs().Binding("outqueue").Write([]byte(`{"message":"message received"}`))
 		return nil
 	}))
 

--- a/_examples/queue-trigger/main.go
+++ b/_examples/queue-trigger/main.go
@@ -21,7 +21,7 @@ func main() {
 		// Log parsed t.
 		ctx.Log().Info("queue message received", "content", t)
 		// Create output to queue.
-		ctx.Outputs().Binding("outqueue").Write([]byte(`{"message":"message received"}`))
+		ctx.Outputs.Binding("outqueue").Write([]byte(`{"message":"message received"}`))
 		return nil
 	}))
 

--- a/_examples/service-bus-queue-trigger/main.go
+++ b/_examples/service-bus-queue-trigger/main.go
@@ -5,13 +5,13 @@ import (
 	"os"
 
 	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/triggers"
+	"github.com/KarlGW/azfunc/trigger"
 )
 
 func main() {
 	app := azfunc.NewFunctionApp(azfunc.WithLogger(azfunc.NewLogger()))
 
-	app.AddFunction("hello-sb-queue", azfunc.ServiceBusTrigger("queue", func(ctx *azfunc.Context, trigger *triggers.ServiceBus) error {
+	app.AddFunction("hello-sb-queue", azfunc.ServiceBusTrigger("queue", func(ctx *azfunc.Context, trigger *trigger.ServiceBus) error {
 		// Parse the incoming service bus queue trigger body into the custom type.
 		// To get the raw data of the service bus message, use trigger.Data instead.
 		var t test

--- a/_examples/service-bus-queue-trigger/main.go
+++ b/_examples/service-bus-queue-trigger/main.go
@@ -21,7 +21,7 @@ func main() {
 		// Log parsed t.
 		ctx.Log().Info("service bus queue message received", "content", t)
 		// Create output to service bus queue.
-		ctx.Outputs().Binding("outqueue").Write([]byte(`{"message":"message received"}`))
+		ctx.Outputs.Binding("outqueue").Write([]byte(`{"message":"message received"}`))
 		return nil
 	}))
 

--- a/_examples/service-bus-queue-trigger/main.go
+++ b/_examples/service-bus-queue-trigger/main.go
@@ -21,7 +21,7 @@ func main() {
 		// Log parsed t.
 		ctx.Log().Info("service bus queue message received", "content", t)
 		// Create output to service bus queue.
-		ctx.Output.Binding("outqueue").Write([]byte(`{"message":"message received"}`))
+		ctx.Outputs().Binding("outqueue").Write([]byte(`{"message":"message received"}`))
 		return nil
 	}))
 

--- a/_examples/timer-trigger/main.go
+++ b/_examples/timer-trigger/main.go
@@ -5,13 +5,13 @@ import (
 	"os"
 
 	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/triggers"
+	"github.com/KarlGW/azfunc/trigger"
 )
 
 func main() {
 	app := azfunc.NewFunctionApp(azfunc.WithLogger(azfunc.NewLogger()))
 
-	app.AddFunction("hello-timer", azfunc.TimerTrigger(func(ctx *azfunc.Context, trigger *triggers.Timer) error {
+	app.AddFunction("hello-timer", azfunc.TimerTrigger(func(ctx *azfunc.Context, trigger *trigger.Timer) error {
 		ctx.Log().Info("timer ran")
 		return nil
 	}))

--- a/binding.go
+++ b/binding.go
@@ -1,0 +1,13 @@
+package azfunc
+
+type binding struct {
+	Name       string   `json:"name,omitempty"`
+	Type       string   `json:"type,omitempty"`
+	Direction  string   `json:"direction,omitempty"`
+	AuthLevel  string   `json:"authLevel,omitempty"`
+	Methods    []string `json:"methods,omitempty"`
+	Route      string   `json:"route,omitempty"`
+	Connection string   `json:"connection,omitempty"`
+	QueueName  string   `json:"queueName,omitempty"`
+	TopicName  string   `json:"topicName,omitempty"`
+}

--- a/context.go
+++ b/context.go
@@ -11,13 +11,8 @@ type Context struct {
 	// clients contains clients defined by the user. It is up to the
 	// user to perform type assertion to handle these services.
 	clients clients
-	// outputs contains output bindings.
-	outputs *outputs
-}
-
-// Outputs returns the outputs set in the Context.
-func (c Context) Outputs() *outputs {
-	return c.outputs
+	// Outputs contains output bindings.
+	Outputs *outputs
 }
 
 // Log returns the logger of the Context.

--- a/context.go
+++ b/context.go
@@ -11,8 +11,13 @@ type Context struct {
 	// clients contains clients defined by the user. It is up to the
 	// user to perform type assertion to handle these services.
 	clients clients
-	// Output contains bindings.
-	Output Output
+	// outputs contains output bindings.
+	outputs *outputs
+}
+
+// Outputs returns the outputs set in the Context.
+func (c Context) Outputs() *outputs {
+	return c.outputs
 }
 
 // Log returns the logger of the Context.

--- a/context_test.go
+++ b/context_test.go
@@ -11,15 +11,15 @@ import (
 
 func TestContext_Output_HTTP_Write(t *testing.T) {
 	ctx := Context{
-		outputs: &outputs{},
+		Outputs: &outputs{},
 	}
-	ctx.Outputs().Add(output.NewHTTP())
-	ctx.Outputs().HTTP().Write([]byte(`{"message":"hello"}`))
+	ctx.Outputs.Add(output.NewHTTP())
+	ctx.Outputs.HTTP().Write([]byte(`{"message":"hello"}`))
 
 	want := output.NewHTTP(func(o *output.HTTPOptions) {
 		o.Body = data.Raw(`{"message":"hello"}`)
 	})
-	got := ctx.Outputs().HTTP()
+	got := ctx.Outputs.HTTP()
 
 	if diff := cmp.Diff(want.Data(), got.Data(), cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
@@ -28,14 +28,14 @@ func TestContext_Output_HTTP_Write(t *testing.T) {
 
 func TestContext_Output_HTTP_WriteHeader(t *testing.T) {
 	ctx := Context{
-		outputs: &outputs{},
+		Outputs: &outputs{},
 	}
-	ctx.Outputs().Add(output.NewHTTP())
-	ctx.Outputs().HTTP().WriteHeader(http.StatusNotFound)
+	ctx.Outputs.Add(output.NewHTTP())
+	ctx.Outputs.HTTP().WriteHeader(http.StatusNotFound)
 
 	want := output.NewHTTP()
 	want.WriteHeader(http.StatusNotFound)
-	got := ctx.Outputs().HTTP()
+	got := ctx.Outputs.HTTP()
 
 	if diff := cmp.Diff(want, got, cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
@@ -44,14 +44,14 @@ func TestContext_Output_HTTP_WriteHeader(t *testing.T) {
 
 func TestContext_Output_HTTP_Header_Add(t *testing.T) {
 	ctx := Context{
-		outputs: &outputs{},
+		Outputs: &outputs{},
 	}
-	ctx.Outputs().Add(output.NewHTTP())
-	ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
+	ctx.Outputs.Add(output.NewHTTP())
+	ctx.Outputs.HTTP().Header().Add("Content-Type", "application/json")
 
 	want := output.NewHTTP()
 	want.Header().Add("Content-Type", "application/json")
-	got := ctx.Outputs().HTTP()
+	got := ctx.Outputs.HTTP()
 
 	if diff := cmp.Diff(want.Header(), got.Header(), cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
@@ -60,11 +60,11 @@ func TestContext_Output_HTTP_Header_Add(t *testing.T) {
 
 func TestContext_Output_Trigger_Write(t *testing.T) {
 	ctx := Context{
-		outputs: &outputs{},
+		Outputs: &outputs{},
 	}
-	ctx.Outputs().Add(output.NewGeneric("queue"))
-	ctx.Outputs().Binding("queue").Write([]byte(`{"message":"hello"}`))
-	got := ctx.Outputs().Binding("queue")
+	ctx.Outputs.Add(output.NewGeneric("queue"))
+	ctx.Outputs.Binding("queue").Write([]byte(`{"message":"hello"}`))
+	got := ctx.Outputs.Binding("queue")
 
 	want := output.NewGeneric("queue")
 	want.Write([]byte(`{"message":"hello"}`))

--- a/context_test.go
+++ b/context_test.go
@@ -11,15 +11,15 @@ import (
 
 func TestContext_Output_HTTP_Write(t *testing.T) {
 	ctx := Context{
-		Output: Output{},
+		outputs: &outputs{},
 	}
-	ctx.Output.AddBindings(output.NewHTTP())
-	ctx.Output.HTTP().Write([]byte(`{"message":"hello"}`))
+	ctx.Outputs().Add(output.NewHTTP())
+	ctx.Outputs().HTTP().Write([]byte(`{"message":"hello"}`))
 
 	want := output.NewHTTP(func(o *output.HTTPOptions) {
 		o.Body = data.Raw(`{"message":"hello"}`)
 	})
-	got := ctx.Output.HTTP()
+	got := ctx.Outputs().HTTP()
 
 	if diff := cmp.Diff(want.Data(), got.Data(), cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
@@ -28,14 +28,14 @@ func TestContext_Output_HTTP_Write(t *testing.T) {
 
 func TestContext_Output_HTTP_WriteHeader(t *testing.T) {
 	ctx := Context{
-		Output: Output{},
+		outputs: &outputs{},
 	}
-	ctx.Output.AddBindings(output.NewHTTP())
-	ctx.Output.HTTP().WriteHeader(http.StatusNotFound)
+	ctx.Outputs().Add(output.NewHTTP())
+	ctx.Outputs().HTTP().WriteHeader(http.StatusNotFound)
 
 	want := output.NewHTTP()
 	want.WriteHeader(http.StatusNotFound)
-	got := ctx.Output.HTTP()
+	got := ctx.Outputs().HTTP()
 
 	if diff := cmp.Diff(want, got, cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
@@ -44,14 +44,14 @@ func TestContext_Output_HTTP_WriteHeader(t *testing.T) {
 
 func TestContext_Output_HTTP_Header_Add(t *testing.T) {
 	ctx := Context{
-		Output: Output{},
+		outputs: &outputs{},
 	}
-	ctx.Output.AddBindings(output.NewHTTP())
-	ctx.Output.HTTP().Header().Add("Content-Type", "application/json")
+	ctx.Outputs().Add(output.NewHTTP())
+	ctx.Outputs().HTTP().Header().Add("Content-Type", "application/json")
 
 	want := output.NewHTTP()
 	want.Header().Add("Content-Type", "application/json")
-	got := ctx.Output.HTTP()
+	got := ctx.Outputs().HTTP()
 
 	if diff := cmp.Diff(want.Header(), got.Header(), cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
@@ -60,11 +60,11 @@ func TestContext_Output_HTTP_Header_Add(t *testing.T) {
 
 func TestContext_Output_Trigger_Write(t *testing.T) {
 	ctx := Context{
-		Output: Output{},
+		outputs: &outputs{},
 	}
-	ctx.Output.AddBindings(output.NewGeneric("queue"))
-	ctx.Output.Binding("queue").Write([]byte(`{"message":"hello"}`))
-	got := ctx.Output.Binding("queue")
+	ctx.Outputs().Add(output.NewGeneric("queue"))
+	ctx.Outputs().Binding("queue").Write([]byte(`{"message":"hello"}`))
+	got := ctx.Outputs().Binding("queue")
 
 	want := output.NewGeneric("queue")
 	want.Write([]byte(`{"message":"hello"}`))

--- a/context_test.go
+++ b/context_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/KarlGW/azfunc/bindings"
 	"github.com/KarlGW/azfunc/data"
+	"github.com/KarlGW/azfunc/output"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -13,15 +13,15 @@ func TestContext_Output_HTTP_Write(t *testing.T) {
 	ctx := Context{
 		Output: Output{},
 	}
-	ctx.Output.AddBindings(bindings.NewHTTP())
+	ctx.Output.AddBindings(output.NewHTTP())
 	ctx.Output.HTTP().Write([]byte(`{"message":"hello"}`))
 
-	want := bindings.NewHTTP(func(o *bindings.HTTPOptions) {
+	want := output.NewHTTP(func(o *output.HTTPOptions) {
 		o.Body = data.Raw(`{"message":"hello"}`)
 	})
 	got := ctx.Output.HTTP()
 
-	if diff := cmp.Diff(want.Data(), got.Data(), cmp.AllowUnexported(bindings.HTTP{})); diff != "" {
+	if diff := cmp.Diff(want.Data(), got.Data(), cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
 	}
 }
@@ -30,14 +30,14 @@ func TestContext_Output_HTTP_WriteHeader(t *testing.T) {
 	ctx := Context{
 		Output: Output{},
 	}
-	ctx.Output.AddBindings(bindings.NewHTTP())
+	ctx.Output.AddBindings(output.NewHTTP())
 	ctx.Output.HTTP().WriteHeader(http.StatusNotFound)
 
-	want := bindings.NewHTTP()
+	want := output.NewHTTP()
 	want.WriteHeader(http.StatusNotFound)
 	got := ctx.Output.HTTP()
 
-	if diff := cmp.Diff(want, got, cmp.AllowUnexported(bindings.HTTP{})); diff != "" {
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
 	}
 }
@@ -46,14 +46,14 @@ func TestContext_Output_HTTP_Header_Add(t *testing.T) {
 	ctx := Context{
 		Output: Output{},
 	}
-	ctx.Output.AddBindings(bindings.NewHTTP())
+	ctx.Output.AddBindings(output.NewHTTP())
 	ctx.Output.HTTP().Header().Add("Content-Type", "application/json")
 
-	want := bindings.NewHTTP()
+	want := output.NewHTTP()
 	want.Header().Add("Content-Type", "application/json")
 	got := ctx.Output.HTTP()
 
-	if diff := cmp.Diff(want.Header(), got.Header(), cmp.AllowUnexported(bindings.HTTP{})); diff != "" {
+	if diff := cmp.Diff(want.Header(), got.Header(), cmp.AllowUnexported(output.HTTP{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
 	}
 }
@@ -62,14 +62,14 @@ func TestContext_Output_Trigger_Write(t *testing.T) {
 	ctx := Context{
 		Output: Output{},
 	}
-	ctx.Output.AddBindings(bindings.NewGeneric("queue"))
+	ctx.Output.AddBindings(output.NewGeneric("queue"))
 	ctx.Output.Binding("queue").Write([]byte(`{"message":"hello"}`))
 	got := ctx.Output.Binding("queue")
 
-	want := bindings.NewGeneric("queue")
+	want := output.NewGeneric("queue")
 	want.Write([]byte(`{"message":"hello"}`))
 
-	if diff := cmp.Diff(want, got, cmp.AllowUnexported(bindings.Generic{})); diff != "" {
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(output.Generic{})); diff != "" {
 		t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
 	}
 }

--- a/function.go
+++ b/function.go
@@ -28,22 +28,22 @@ var (
 // function is an internal structure that represents a function
 // in a FunctionApp.
 type function struct {
-	name     string
-	trigger  triggerable
-	bindings []bindable
+	name    string
+	trigger triggerable
+	outputs []outputable
 }
 
 // FunctionOption sets options to the function.
 type FunctionOption func(f *function)
 
-// Binding sets the provided binding to the function.
-func Binding(binding bindable) FunctionOption {
+// WithOutput sets the provided output binding to the function.
+func WithOutput(output outputable) FunctionOption {
 	return func(f *function) {
-		if f.bindings == nil {
-			f.bindings = []bindable{binding}
+		if f.outputs == nil {
+			f.outputs = []outputable{output}
 			return
 		}
-		f.bindings = append(f.bindings, binding)
+		f.outputs = append(f.outputs, output)
 	}
 }
 
@@ -180,7 +180,7 @@ func (a *FunctionApp) AddFunction(name string, options ...FunctionOption) {
 func (a FunctionApp) handler(fn function) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := &Context{
-			Output:   NewOutput(WithBindings(fn.bindings...)),
+			Output:   NewOutput(WithOutputs(fn.outputs...)),
 			log:      a.log,
 			services: a.services,
 			clients:  a.clients,

--- a/function.go
+++ b/function.go
@@ -221,7 +221,7 @@ func (a *functionApp) Register(name string, options ...FunctionOption) {
 func (a functionApp) handler(fn function) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := &Context{
-			outputs:  newOutputs(withOutputs(fn.outputs...)),
+			Outputs:  newOutputs(withOutputs(fn.outputs...)),
 			log:      a.log,
 			services: a.services,
 			clients:  a.clients,
@@ -234,7 +234,7 @@ func (a functionApp) handler(fn function) http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(ctx.Outputs().json())
+		w.Write(ctx.Outputs.json())
 	})
 }
 

--- a/function.go
+++ b/function.go
@@ -47,9 +47,9 @@ func WithOutput(output outputable) FunctionOption {
 	}
 }
 
-// FunctionApp represents a Function App with its configuration
+// functionApp represents a Function App with its configuration
 // and functions.
-type FunctionApp struct {
+type functionApp struct {
 	httpServer *http.Server
 	router     *http.ServeMux
 	// functions that are set on the FunctionApp.
@@ -69,17 +69,48 @@ type FunctionApp struct {
 
 // FunctionAppOption is a function that sets options to a
 // FunctionApp.
-type FunctionAppOption func(*FunctionApp)
+type FunctionAppOption func(*functionApp)
 
-// NewFunction app creates and configures a FunctionApp.
-func NewFunctionApp(options ...FunctionAppOption) *FunctionApp {
+// NewFunctionApp creates and configures a FunctionApp.
+func NewFunctionApp(options ...FunctionAppOption) *functionApp {
 	port, ok := os.LookupEnv(functionsCustomHandlerPort)
 	if !ok {
 		port = "8080"
 	}
 
 	router := http.NewServeMux()
-	app := &FunctionApp{
+	app := &functionApp{
+		httpServer: &http.Server{
+			Addr:         os.Getenv(functionsCustomHandlerHost) + ":" + port,
+			Handler:      router,
+			ReadTimeout:  time.Second * 30,
+			WriteTimeout: time.Second * 30,
+			IdleTimeout:  time.Second * 60,
+		},
+		functions: make(map[string]function),
+		router:    router,
+		stopCh:    make(chan os.Signal),
+		errCh:     make(chan error),
+	}
+	for _, option := range options {
+		option(app)
+	}
+	if app.log == nil {
+		app.log = noOpLogger{}
+	}
+
+	return app
+}
+
+// New creates and configures a FunctionApp.
+func New(options ...FunctionAppOption) *functionApp {
+	port, ok := os.LookupEnv(functionsCustomHandlerPort)
+	if !ok {
+		port = "8080"
+	}
+
+	router := http.NewServeMux()
+	app := &functionApp{
 		httpServer: &http.Server{
 			Addr:         os.Getenv(functionsCustomHandlerHost) + ":" + port,
 			Handler:      router,
@@ -103,7 +134,7 @@ func NewFunctionApp(options ...FunctionAppOption) *FunctionApp {
 }
 
 // Start the FunctionApp.
-func (a FunctionApp) Start() error {
+func (a functionApp) Start() error {
 	if len(a.functions) == 0 {
 		return ErrNoFunction
 	}
@@ -144,7 +175,7 @@ func (a FunctionApp) Start() error {
 }
 
 // stop the FunctionApp.
-func (a FunctionApp) stop() {
+func (a functionApp) stop() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	sig := <-stop
@@ -161,7 +192,7 @@ func (a FunctionApp) stop() {
 }
 
 // AddFunction adds a function to the FunctionApp.
-func (a *FunctionApp) AddFunction(name string, options ...FunctionOption) {
+func (a *functionApp) AddFunction(name string, options ...FunctionOption) {
 	if a.functions == nil {
 		a.functions = make(map[string]function)
 	}
@@ -174,13 +205,23 @@ func (a *FunctionApp) AddFunction(name string, options ...FunctionOption) {
 	a.functions[name] = f
 }
 
+// Add a function to the FunctionApp.
+func (a *functionApp) Add(name string, options ...FunctionOption) {
+	a.AddFunction(name, options...)
+}
+
+// Register a function to the FunctionApp.
+func (a *functionApp) Register(name string, options ...FunctionOption) {
+	a.AddFunction(name, options...)
+}
+
 // handler takes the provided function, creates a *Context and a trigger
 // and executes the function on the route it has been configured
 // with (the function name).
-func (a FunctionApp) handler(fn function) http.Handler {
+func (a functionApp) handler(fn function) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := &Context{
-			Output:   NewOutput(WithOutputs(fn.outputs...)),
+			outputs:  newOutputs(withOutputs(fn.outputs...)),
 			log:      a.log,
 			services: a.services,
 			clients:  a.clients,
@@ -193,7 +234,7 @@ func (a FunctionApp) handler(fn function) http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(ctx.Output.JSON())
+		w.Write(ctx.Outputs().json())
 	})
 }
 
@@ -201,7 +242,7 @@ func (a FunctionApp) handler(fn function) http.Handler {
 // called multiple times. If a service with the same name
 // has been set it will be overwritten.
 func WithService(name string, service any) FunctionAppOption {
-	return func(f *FunctionApp) {
+	return func(f *functionApp) {
 		f.services.Add(name, service)
 	}
 }
@@ -210,7 +251,7 @@ func WithService(name string, service any) FunctionAppOption {
 // called multiple times. If a client with the same name
 // has been set it will be overwritten.
 func WithClient(name string, client any) FunctionAppOption {
-	return func(f *FunctionApp) {
+	return func(f *functionApp) {
 		f.clients.Add(name, client)
 	}
 }
@@ -218,7 +259,7 @@ func WithClient(name string, client any) FunctionAppOption {
 // WithLogger sets the provided logger to the FunctionApp.
 // The logger must satisfy the logger interface.
 func WithLogger(log logger) FunctionAppOption {
-	return func(f *FunctionApp) {
+	return func(f *functionApp) {
 		f.log = log
 	}
 }

--- a/output.go
+++ b/output.go
@@ -62,7 +62,7 @@ func (o outputs) json() []byte {
 	return b
 }
 
-// addOutputs one or more output bindings to functionOutput.
+// Add one or more output bindings to functionOutput.
 func (o *outputs) Add(outputs ...outputable) {
 	if o.outputs == nil {
 		o.outputs = make(map[string]outputable, len(outputs))

--- a/output/generic.go
+++ b/output/generic.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import "github.com/KarlGW/azfunc/data"
 

--- a/output/generic_test.go
+++ b/output/generic_test.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import (
 	"testing"

--- a/output/http.go
+++ b/output/http.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import (
 	"encoding/json"

--- a/output/http_test.go
+++ b/output/http_test.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import (
 	"net/http"

--- a/output/queue.go
+++ b/output/queue.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import "github.com/KarlGW/azfunc/data"
 

--- a/output/queue_test.go
+++ b/output/queue_test.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import (
 	"testing"
@@ -7,25 +7,25 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestNewServiceBus(t *testing.T) {
+func TestNewQueue(t *testing.T) {
 	var tests = []struct {
 		name  string
 		input struct {
 			name    string
-			options []ServiceBusOption
+			options []QueueOption
 		}
-		want *ServiceBus
+		want *Queue
 	}{
 		{
 			name: "defaults",
 			input: struct {
 				name    string
-				options []ServiceBusOption
+				options []QueueOption
 			}{
 				name:    "queue",
 				options: nil,
 			},
-			want: &ServiceBus{
+			want: &Queue{
 				name: "queue",
 				data: nil,
 			},
@@ -34,16 +34,16 @@ func TestNewServiceBus(t *testing.T) {
 			name: "with options",
 			input: struct {
 				name    string
-				options []ServiceBusOption
+				options []QueueOption
 			}{
 				name: "queue",
-				options: []ServiceBusOption{
-					func(o *ServiceBusOptions) {
+				options: []QueueOption{
+					func(o *QueueOptions) {
 						o.Data = data.Raw(`{"message":"hello"}`)
 					},
 				},
 			},
-			want: &ServiceBus{
+			want: &Queue{
 				name: "queue",
 				data: data.Raw(`{"message":"hello"}`),
 			},
@@ -52,39 +52,50 @@ func TestNewServiceBus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := NewServiceBus(test.want.name, test.input.options...)
+			got := NewQueue(test.input.name, test.input.options...)
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(ServiceBus{})); diff != "" {
-				t.Errorf("NewServiceBus() = unexpected (-want +got)\n%s\n", diff)
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Queue{})); diff != "" {
+				t.Errorf("NewQueue() = unexpected (-want +got)\n%s\n", diff)
 			}
 		})
 	}
 }
 
-func TestServiceBus_Write(t *testing.T) {
+func TestQueue_Write(t *testing.T) {
 	t.Run("Write", func(t *testing.T) {
-		got := &ServiceBus{}
+		got := &Queue{}
 		got.Write([]byte(`{"message":"hello"}`))
-		want := &ServiceBus{data: data.Raw(`{"message":"hello"}`)}
+		want := &Queue{data: data.Raw(`{"message":"hello"}`)}
 
-		if diff := cmp.Diff(want, got, cmp.AllowUnexported(ServiceBus{})); diff != "" {
+		if diff := cmp.Diff(want, got, cmp.AllowUnexported(Queue{})); diff != "" {
 			t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
 		}
 	})
 }
 
-func TestServiceBus_Name(t *testing.T) {
+func TestQueue_Name(t *testing.T) {
 	var tests = []struct {
 		name  string
-		input *ServiceBus
+		input *Queue
 		want  string
-	}{}
+	}{
+		{
+			name:  "default",
+			input: &Queue{},
+			want:  "",
+		},
+		{
+			name:  "with name",
+			input: &Queue{name: "queue"},
+			want:  "queue",
+		},
+	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.input.Name()
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(ServiceBus{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Queue{})); diff != "" {
 				t.Errorf("Name() = unexpected result (-want +got)\n%s\n", diff)
 			}
 		})

--- a/output/service_bus.go
+++ b/output/service_bus.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import "github.com/KarlGW/azfunc/data"
 

--- a/output/service_bus_test.go
+++ b/output/service_bus_test.go
@@ -1,4 +1,4 @@
-package bindings
+package output
 
 import (
 	"testing"
@@ -7,25 +7,25 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestNewQueue(t *testing.T) {
+func TestNewServiceBus(t *testing.T) {
 	var tests = []struct {
 		name  string
 		input struct {
 			name    string
-			options []QueueOption
+			options []ServiceBusOption
 		}
-		want *Queue
+		want *ServiceBus
 	}{
 		{
 			name: "defaults",
 			input: struct {
 				name    string
-				options []QueueOption
+				options []ServiceBusOption
 			}{
 				name:    "queue",
 				options: nil,
 			},
-			want: &Queue{
+			want: &ServiceBus{
 				name: "queue",
 				data: nil,
 			},
@@ -34,16 +34,16 @@ func TestNewQueue(t *testing.T) {
 			name: "with options",
 			input: struct {
 				name    string
-				options []QueueOption
+				options []ServiceBusOption
 			}{
 				name: "queue",
-				options: []QueueOption{
-					func(o *QueueOptions) {
+				options: []ServiceBusOption{
+					func(o *ServiceBusOptions) {
 						o.Data = data.Raw(`{"message":"hello"}`)
 					},
 				},
 			},
-			want: &Queue{
+			want: &ServiceBus{
 				name: "queue",
 				data: data.Raw(`{"message":"hello"}`),
 			},
@@ -52,50 +52,39 @@ func TestNewQueue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := NewQueue(test.input.name, test.input.options...)
+			got := NewServiceBus(test.want.name, test.input.options...)
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Queue{})); diff != "" {
-				t.Errorf("NewQueue() = unexpected (-want +got)\n%s\n", diff)
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(ServiceBus{})); diff != "" {
+				t.Errorf("NewServiceBus() = unexpected (-want +got)\n%s\n", diff)
 			}
 		})
 	}
 }
 
-func TestQueue_Write(t *testing.T) {
+func TestServiceBus_Write(t *testing.T) {
 	t.Run("Write", func(t *testing.T) {
-		got := &Queue{}
+		got := &ServiceBus{}
 		got.Write([]byte(`{"message":"hello"}`))
-		want := &Queue{data: data.Raw(`{"message":"hello"}`)}
+		want := &ServiceBus{data: data.Raw(`{"message":"hello"}`)}
 
-		if diff := cmp.Diff(want, got, cmp.AllowUnexported(Queue{})); diff != "" {
+		if diff := cmp.Diff(want, got, cmp.AllowUnexported(ServiceBus{})); diff != "" {
 			t.Errorf("Write() = unexpected result (-want +got)\n%s\n", diff)
 		}
 	})
 }
 
-func TestQueue_Name(t *testing.T) {
+func TestServiceBus_Name(t *testing.T) {
 	var tests = []struct {
 		name  string
-		input *Queue
+		input *ServiceBus
 		want  string
-	}{
-		{
-			name:  "default",
-			input: &Queue{},
-			want:  "",
-		},
-		{
-			name:  "with name",
-			input: &Queue{name: "queue"},
-			want:  "queue",
-		},
-	}
+	}{}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.input.Name()
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Queue{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(ServiceBus{})); diff != "" {
 				t.Errorf("Name() = unexpected result (-want +got)\n%s\n", diff)
 			}
 		})

--- a/output_test.go
+++ b/output_test.go
@@ -12,36 +12,36 @@ import (
 func TestNewOutput(t *testing.T) {
 	var tests = []struct {
 		name  string
-		input []OutputOption
-		want  Output
+		input []outputsOption
+		want  *outputs
 	}{
 		{
 			name:  "Output with defaults",
 			input: nil,
-			want: Output{
-				Outputs:     map[string]outputable{},
-				Logs:        nil,
-				ReturnValue: nil,
+			want: &outputs{
+				outputs:     map[string]outputable{},
+				logs:        nil,
+				returnValue: nil,
 			},
 		},
 		{
 			name: "Output with options",
-			input: []OutputOption{
-				func(o *OutputOptions) {
-					o.Bindings = []outputable{
+			input: []outputsOption{
+				func(o *outputsOptions) {
+					o.outputs = []outputable{
 						output.NewHTTP(),
 						output.NewGeneric("queue"),
 					}
 					o.Logs = []string{"Log message"}
-					o.ReturnValue = 0
+					o.returnValue = 0
 				},
 			},
-			want: Output{
-				Outputs: map[string]outputable{
+			want: &outputs{
+				outputs: map[string]outputable{
 					"queue": output.NewGeneric("queue"),
 				},
-				Logs:        []string{"Log message"},
-				ReturnValue: 0,
+				logs:        []string{"Log message"},
+				returnValue: 0,
 				http:        output.NewHTTP(),
 			},
 		},
@@ -49,9 +49,9 @@ func TestNewOutput(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := NewOutput(test.input...)
+			got := newOutputs(test.input...)
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Output{}, output.HTTP{}, output.Generic{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(outputs{}, output.HTTP{}, output.Generic{})); diff != "" {
 				t.Errorf("NewOutput() = unexpected result (-want +got)\n%s\n", diff)
 			}
 		})
@@ -61,13 +61,13 @@ func TestNewOutput(t *testing.T) {
 func TestOutput_JSON(t *testing.T) {
 	var tests = []struct {
 		name  string
-		input Output
+		input outputs
 		want  []byte
 	}{
 		{
 			name: "Parse output to JSON",
-			input: Output{
-				Outputs: map[string]outputable{
+			input: outputs{
+				outputs: map[string]outputable{
 					"queue": output.NewGeneric("queue", func(o *output.GenericOptions) {
 						o.Data = []byte(`{"message":"hello","number":3}`)
 					}),
@@ -79,8 +79,8 @@ func TestOutput_JSON(t *testing.T) {
 						"Content-Type": {"application/json"},
 					}
 				}),
-				Logs:        nil,
-				ReturnValue: nil,
+				logs:        nil,
+				returnValue: nil,
 			},
 			want: output1,
 		},
@@ -88,7 +88,7 @@ func TestOutput_JSON(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.input.JSON()
+			got := test.input.json()
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("JSON() = unexpected result (-want +got)\n%s\n", diff)
 			}

--- a/output_test.go
+++ b/output_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/KarlGW/azfunc/bindings"
 	"github.com/KarlGW/azfunc/data"
+	"github.com/KarlGW/azfunc/output"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -19,7 +19,7 @@ func TestNewOutput(t *testing.T) {
 			name:  "Output with defaults",
 			input: nil,
 			want: Output{
-				Outputs:     map[string]bindable{},
+				Outputs:     map[string]outputable{},
 				Logs:        nil,
 				ReturnValue: nil,
 			},
@@ -28,21 +28,21 @@ func TestNewOutput(t *testing.T) {
 			name: "Output with options",
 			input: []OutputOption{
 				func(o *OutputOptions) {
-					o.Bindings = []bindable{
-						bindings.NewHTTP(),
-						bindings.NewGeneric("queue"),
+					o.Bindings = []outputable{
+						output.NewHTTP(),
+						output.NewGeneric("queue"),
 					}
 					o.Logs = []string{"Log message"}
 					o.ReturnValue = 0
 				},
 			},
 			want: Output{
-				Outputs: map[string]bindable{
-					"queue": bindings.NewGeneric("queue"),
+				Outputs: map[string]outputable{
+					"queue": output.NewGeneric("queue"),
 				},
 				Logs:        []string{"Log message"},
 				ReturnValue: 0,
-				http:        bindings.NewHTTP(),
+				http:        output.NewHTTP(),
 			},
 		},
 	}
@@ -51,7 +51,7 @@ func TestNewOutput(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := NewOutput(test.input...)
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Output{}, bindings.HTTP{}, bindings.Generic{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Output{}, output.HTTP{}, output.Generic{})); diff != "" {
 				t.Errorf("NewOutput() = unexpected result (-want +got)\n%s\n", diff)
 			}
 		})
@@ -67,12 +67,12 @@ func TestOutput_JSON(t *testing.T) {
 		{
 			name: "Parse output to JSON",
 			input: Output{
-				Outputs: map[string]bindable{
-					"queue": bindings.NewGeneric("queue", func(o *bindings.GenericOptions) {
+				Outputs: map[string]outputable{
+					"queue": output.NewGeneric("queue", func(o *output.GenericOptions) {
 						o.Data = []byte(`{"message":"hello","number":3}`)
 					}),
 				},
-				http: bindings.NewHTTP(func(o *bindings.HTTPOptions) {
+				http: output.NewHTTP(func(o *output.HTTPOptions) {
 					o.StatusCode = http.StatusOK
 					o.Body = data.Raw(`{"message":"hello","number":2}`)
 					o.Header = http.Header{

--- a/trigger/event_grid.go
+++ b/trigger/event_grid.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"encoding/json"

--- a/trigger/event_grid_test.go
+++ b/trigger/event_grid_test.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"bytes"

--- a/trigger/generic.go
+++ b/trigger/generic.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"encoding/json"

--- a/trigger/generic_test.go
+++ b/trigger/generic_test.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"bytes"

--- a/trigger/http.go
+++ b/trigger/http.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"bytes"

--- a/trigger/http_test.go
+++ b/trigger/http_test.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"bytes"

--- a/trigger/queue.go
+++ b/trigger/queue.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"encoding/json"

--- a/trigger/queue_test.go
+++ b/trigger/queue_test.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"bytes"

--- a/trigger/service_bus.go
+++ b/trigger/service_bus.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"encoding/json"

--- a/trigger/service_bus_test.go
+++ b/trigger/service_bus_test.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"bytes"

--- a/trigger/time.go
+++ b/trigger/time.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"strings"

--- a/trigger/timer.go
+++ b/trigger/timer.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"encoding/json"

--- a/trigger/timer_test.go
+++ b/trigger/timer_test.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"bytes"

--- a/trigger/triggers.go
+++ b/trigger/triggers.go
@@ -1,4 +1,4 @@
-package triggers
+package trigger
 
 import (
 	"errors"

--- a/triggers.go
+++ b/triggers.go
@@ -3,7 +3,7 @@ package azfunc
 import (
 	"net/http"
 
-	"github.com/KarlGW/azfunc/triggers"
+	"github.com/KarlGW/azfunc/trigger"
 )
 
 // triggerable is the interface that wraps around the method run.
@@ -12,18 +12,18 @@ type triggerable interface {
 }
 
 // GenericTriggerFunc represents a generic function to be executed by the function app.
-type GenericTriggerFunc func(ctx *Context, trigger *triggers.Generic) error
+type GenericTriggerFunc func(ctx *Context, trigger *trigger.Generic) error
 
 // genericTrigger contains the trigger func, name and options of the trigger.
 type genericTrigger struct {
 	fn      GenericTriggerFunc
 	name    string
-	options []triggers.GenericOption
+	options []trigger.GenericOption
 }
 
 // run creates the trigger and runs the trigger func.
 func (t genericTrigger) run(ctx *Context, r *http.Request) error {
-	tr, err := triggers.NewGeneric(r, t.name, t.options...)
+	tr, err := trigger.NewGeneric(r, t.name, t.options...)
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,7 @@ func (t genericTrigger) run(ctx *Context, r *http.Request) error {
 
 // GenericTrigger takes the provided name and function and sets it as
 // the function to be run by the trigger.
-func GenericTrigger(name string, fn GenericTriggerFunc, options ...triggers.GenericOption) FunctionOption {
+func GenericTrigger(name string, fn GenericTriggerFunc, options ...trigger.GenericOption) FunctionOption {
 	return func(f *function) {
 		f.trigger = genericTrigger{
 			fn:      fn,
@@ -43,17 +43,17 @@ func GenericTrigger(name string, fn GenericTriggerFunc, options ...triggers.Gene
 }
 
 // HTTPTriggerFunc represents an HTTP trigger function to be executed by the function app.
-type HTTPTriggerFunc func(ctx *Context, trigger *triggers.HTTP) error
+type HTTPTriggerFunc func(ctx *Context, trigger *trigger.HTTP) error
 
 // httpTrigger contains the trigger func and name of the trigger.
 type httpTrigger struct {
 	fn      HTTPTriggerFunc
-	options []triggers.HTTPOption
+	options []trigger.HTTPOption
 }
 
 // run creates the trigger and runs the trigger func.
 func (t httpTrigger) run(ctx *Context, r *http.Request) error {
-	tr, err := triggers.NewHTTP(r, t.options...)
+	tr, err := trigger.NewHTTP(r, t.options...)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (t httpTrigger) run(ctx *Context, r *http.Request) error {
 
 // HTTPTrigger takes the provided function and sets it as
 // the function to be run by the trigger.
-func HTTPTrigger(fn HTTPTriggerFunc, options ...triggers.HTTPOption) FunctionOption {
+func HTTPTrigger(fn HTTPTriggerFunc, options ...trigger.HTTPOption) FunctionOption {
 	return func(f *function) {
 		f.trigger = httpTrigger{
 			fn:      fn,
@@ -72,17 +72,17 @@ func HTTPTrigger(fn HTTPTriggerFunc, options ...triggers.HTTPOption) FunctionOpt
 }
 
 // TimerTriggerFunc represents a Timer trigger function tp be executed by the function app.
-type TimerTriggerFunc func(ctx *Context, trigger *triggers.Timer) error
+type TimerTriggerFunc func(ctx *Context, trigger *trigger.Timer) error
 
 // timerTrigger contains the trigger func and name of the trigger.
 type timerTrigger struct {
 	fn      TimerTriggerFunc
-	options []triggers.TimerOption
+	options []trigger.TimerOption
 }
 
 // run creates the trigger and runs the trigger func.
 func (t timerTrigger) run(ctx *Context, r *http.Request) error {
-	tr, err := triggers.NewTimer(r, t.options...)
+	tr, err := trigger.NewTimer(r, t.options...)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (t timerTrigger) run(ctx *Context, r *http.Request) error {
 
 // TimerTrigger takes the provided function and sets it as
 // the function to be run by the trigger.
-func TimerTrigger(fn TimerTriggerFunc, options ...triggers.TimerOption) FunctionOption {
+func TimerTrigger(fn TimerTriggerFunc, options ...trigger.TimerOption) FunctionOption {
 	return func(f *function) {
 		f.trigger = timerTrigger{
 			fn:      fn,
@@ -102,18 +102,18 @@ func TimerTrigger(fn TimerTriggerFunc, options ...triggers.TimerOption) Function
 
 // QueueTriggerFunc represents a Queue Storage trigger function to be exexuted
 // by the function app.
-type QueueTriggerFunc func(ctx *Context, trigger *triggers.Queue) error
+type QueueTriggerFunc func(ctx *Context, trigger *trigger.Queue) error
 
 // queueTrigger contains the trigger func, name and options of the trigger.
 type queueTrigger struct {
 	fn      QueueTriggerFunc
 	name    string
-	options []triggers.QueueOption
+	options []trigger.QueueOption
 }
 
 // run creates the trigger and runs the trigger func.
 func (t queueTrigger) run(ctx *Context, r *http.Request) error {
-	tr, err := triggers.NewQueue(r, t.name, t.options...)
+	tr, err := trigger.NewQueue(r, t.name, t.options...)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (t queueTrigger) run(ctx *Context, r *http.Request) error {
 
 // QueueTrigger takes the provided name and function and sets it as
 // the function to be run by the trigger.
-func QueueTrigger(name string, fn QueueTriggerFunc, options ...triggers.QueueOption) FunctionOption {
+func QueueTrigger(name string, fn QueueTriggerFunc, options ...trigger.QueueOption) FunctionOption {
 	return func(f *function) {
 		f.trigger = queueTrigger{
 			fn:      fn,
@@ -134,18 +134,18 @@ func QueueTrigger(name string, fn QueueTriggerFunc, options ...triggers.QueueOpt
 
 // ServiceBusTriggerFunc represents a Service Bus trigger function to be exexuted
 // by the function app.
-type ServiceBusTriggerFunc func(ctx *Context, trigger *triggers.ServiceBus) error
+type ServiceBusTriggerFunc func(ctx *Context, trigger *trigger.ServiceBus) error
 
 // serviceBusTrigger contains the trigger func, name and options of the trigger.
 type serviceBusTrigger struct {
 	fn      ServiceBusTriggerFunc
 	name    string
-	options []triggers.ServiceBusOption
+	options []trigger.ServiceBusOption
 }
 
 // run creates the trigger and runs the trigger func.
 func (t serviceBusTrigger) run(ctx *Context, r *http.Request) error {
-	tr, err := triggers.NewServiceBus(r, t.name, t.options...)
+	tr, err := trigger.NewServiceBus(r, t.name, t.options...)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (t serviceBusTrigger) run(ctx *Context, r *http.Request) error {
 
 // ServiceBusTrigger takes the provided name and function and sets it as
 // the function to be run by the trigger.
-func ServiceBusTrigger(name string, fn ServiceBusTriggerFunc, options ...triggers.ServiceBusOption) FunctionOption {
+func ServiceBusTrigger(name string, fn ServiceBusTriggerFunc, options ...trigger.ServiceBusOption) FunctionOption {
 	return func(f *function) {
 		f.trigger = serviceBusTrigger{
 			fn:      fn,
@@ -166,18 +166,18 @@ func ServiceBusTrigger(name string, fn ServiceBusTriggerFunc, options ...trigger
 
 // EventGridTriggerFunc represents an Event Grid trigger function to be executed by
 // the function app.
-type EventGridTriggerFunc func(ctx *Context, trigger *triggers.EventGrid) error
+type EventGridTriggerFunc func(ctx *Context, trigger *trigger.EventGrid) error
 
 // eventGridTrigger contains the trigger func, name and options of the trigger.
 type eventGridTrigger struct {
 	fn      EventGridTriggerFunc
 	name    string
-	options []triggers.EventGridOption
+	options []trigger.EventGridOption
 }
 
 // run creates the trigger and runs the trigger func.
 func (t eventGridTrigger) run(ctx *Context, r *http.Request) error {
-	tr, err := triggers.NewEventGrid(r, t.name, t.options...)
+	tr, err := trigger.NewEventGrid(r, t.name, t.options...)
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func (t eventGridTrigger) run(ctx *Context, r *http.Request) error {
 
 // EventGridTrigger takes the provided name and function and sets it as
 // the function to be run by the trigger.
-func EventGridTrigger(name string, fn EventGridTriggerFunc, options ...triggers.EventGridOption) FunctionOption {
+func EventGridTrigger(name string, fn EventGridTriggerFunc, options ...trigger.EventGridOption) FunctionOption {
 	return func(f *function) {
 		f.trigger = eventGridTrigger{
 			fn:      fn,


### PR DESCRIPTION
Packages `triggers` and `bindings` have been renamed to `trigger` and `output` to both match Go naming conventions better, as well as the terminology used på Azure functions.

A trigger is the input binding and an output is the output binding.  Both are bindings in their own way.