### PR TITLE
convert header keys to canonical form

### DIFF
--- a/_examples/http-trigger-queue-output/go.mod
+++ b/_examples/http-trigger-queue-output/go.mod
@@ -2,6 +2,6 @@ module http-trigger-queue-output
 
 go 1.21.3
 
-replace github.com/KarlGW/azfunc => ../../
+replace github.com/potatoattack/azfunc => ../../
 
-require github.com/KarlGW/azfunc v0.0.0-00010101000000-000000000000
+require github.com/potatoattack/azfunc v0.0.0-00010101000000-000000000000

--- a/_examples/http-trigger-queue-output/main.go
+++ b/_examples/http-trigger-queue-output/main.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/trigger"
+	"github.com/potatoattack/azfunc"
+	"github.com/potatoattack/azfunc/trigger"
 )
 
 func main() {

--- a/_examples/http-trigger/go.mod
+++ b/_examples/http-trigger/go.mod
@@ -2,6 +2,6 @@ module http-trigger
 
 go 1.21.3
 
-replace github.com/KarlGW/azfunc => ../../
+replace github.com/potatoattack/azfunc => ../../
 
-require github.com/KarlGW/azfunc v0.0.0-00010101000000-000000000000
+require github.com/potatoattack/azfunc v0.0.0-00010101000000-000000000000

--- a/_examples/http-trigger/main.go
+++ b/_examples/http-trigger/main.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/trigger"
+	"github.com/potatoattack/azfunc"
+	"github.com/potatoattack/azfunc/trigger"
 )
 
 func main() {

--- a/_examples/queue-trigger/go.mod
+++ b/_examples/queue-trigger/go.mod
@@ -2,6 +2,6 @@ module queue-trigger
 
 go 1.21.3
 
-replace github.com/KarlGW/azfunc => ../../
+replace github.com/potatoattack/azfunc => ../../
 
-require github.com/KarlGW/azfunc v0.0.0-00010101000000-000000000000
+require github.com/potatoattack/azfunc v0.0.0-00010101000000-000000000000

--- a/_examples/queue-trigger/main.go
+++ b/_examples/queue-trigger/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/trigger"
+	"github.com/potatoattack/azfunc"
+	"github.com/potatoattack/azfunc/trigger"
 )
 
 func main() {

--- a/_examples/service-bus-queue-trigger/go.mod
+++ b/_examples/service-bus-queue-trigger/go.mod
@@ -2,6 +2,6 @@ module service-bus-queue-trigger
 
 go 1.21.3
 
-replace github.com/KarlGW/azfunc => ../../
+replace github.com/potatoattack/azfunc => ../../
 
-require github.com/KarlGW/azfunc v0.0.0-00010101000000-000000000000
+require github.com/potatoattack/azfunc v0.0.0-00010101000000-000000000000

--- a/_examples/service-bus-queue-trigger/main.go
+++ b/_examples/service-bus-queue-trigger/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/trigger"
+	"github.com/potatoattack/azfunc"
+	"github.com/potatoattack/azfunc/trigger"
 )
 
 func main() {

--- a/_examples/timer-trigger/go.mod
+++ b/_examples/timer-trigger/go.mod
@@ -2,6 +2,6 @@ module timer-trigger
 
 go 1.21.3
 
-replace github.com/KarlGW/azfunc => ../../
+replace github.com/potatoattack/azfunc => ../../
 
-require github.com/KarlGW/azfunc v0.0.0-00010101000000-000000000000
+require github.com/potatoattack/azfunc v0.0.0-00010101000000-000000000000

--- a/_examples/timer-trigger/main.go
+++ b/_examples/timer-trigger/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/KarlGW/azfunc"
-	"github.com/KarlGW/azfunc/trigger"
+	"github.com/potatoattack/azfunc"
+	"github.com/potatoattack/azfunc/trigger"
 )
 
 func main() {

--- a/context_test.go
+++ b/context_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/KarlGW/azfunc/data"
-	"github.com/KarlGW/azfunc/output"
+	"github.com/potatoattack/azfunc/data"
+	"github.com/potatoattack/azfunc/output"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/eventgrid/event_grid.go
+++ b/eventgrid/event_grid.go
@@ -3,7 +3,7 @@ package eventgrid
 import (
 	"time"
 
-	"github.com/KarlGW/azfunc/uuid"
+	"github.com/potatoattack/azfunc/uuid"
 )
 
 // Schema represents the schema of the event.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/KarlGW/azfunc
+module github.com/potatoattack/azfunc
 
 go 1.21
 

--- a/output.go
+++ b/output.go
@@ -3,8 +3,8 @@ package azfunc
 import (
 	"encoding/json"
 
-	"github.com/KarlGW/azfunc/data"
-	"github.com/KarlGW/azfunc/output"
+	"github.com/potatoattack/azfunc/data"
+	"github.com/potatoattack/azfunc/output"
 )
 
 // outputable is the interface that wraps around methods Data, Name and Write.

--- a/output/event_grid.go
+++ b/output/event_grid.go
@@ -1,7 +1,7 @@
 package output
 
 import (
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 )
 
 // EventGrid represents an Event Grid output binding.

--- a/output/event_grid_test.go
+++ b/output/event_grid_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/KarlGW/azfunc/data"
-	"github.com/KarlGW/azfunc/eventgrid"
+	"github.com/potatoattack/azfunc/data"
+	"github.com/potatoattack/azfunc/eventgrid"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/output/generic.go
+++ b/output/generic.go
@@ -1,6 +1,6 @@
 package output
 
-import "github.com/KarlGW/azfunc/data"
+import "github.com/potatoattack/azfunc/data"
 
 // Generic represents a generic output binding. With custom handlers
 // all bindings that are not HTTP output bindings share the

--- a/output/generic_test.go
+++ b/output/generic_test.go
@@ -3,7 +3,7 @@ package output
 import (
 	"testing"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/output/http.go
+++ b/output/http.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 )
 
 // HTTP represents an HTTP output binding.

--- a/output/http_test.go
+++ b/output/http_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/output/queue.go
+++ b/output/queue.go
@@ -1,6 +1,6 @@
 package output
 
-import "github.com/KarlGW/azfunc/data"
+import "github.com/potatoattack/azfunc/data"
 
 // Queue represents a Queue Storage output binding.
 type Queue struct {

--- a/output/queue_test.go
+++ b/output/queue_test.go
@@ -3,7 +3,7 @@ package output
 import (
 	"testing"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/output/service_bus.go
+++ b/output/service_bus.go
@@ -1,6 +1,6 @@
 package output
 
-import "github.com/KarlGW/azfunc/data"
+import "github.com/potatoattack/azfunc/data"
 
 // ServiceBus represents a service bus output binding.
 type ServiceBus struct {

--- a/output/service_bus_test.go
+++ b/output/service_bus_test.go
@@ -3,7 +3,7 @@ package output
 import (
 	"testing"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/output_test.go
+++ b/output_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/KarlGW/azfunc/data"
-	"github.com/KarlGW/azfunc/output"
+	"github.com/potatoattack/azfunc/data"
+	"github.com/potatoattack/azfunc/output"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/trigger/event_grid.go
+++ b/trigger/event_grid.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/KarlGW/azfunc/eventgrid"
+	"github.com/potatoattack/azfunc/eventgrid"
 )
 
 // EventGrid represents an Event Grid trigger. It handles both

--- a/trigger/event_grid_test.go
+++ b/trigger/event_grid_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/KarlGW/azfunc/eventgrid"
+	"github.com/potatoattack/azfunc/eventgrid"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/trigger/generic.go
+++ b/trigger/generic.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 )
 
 // Generic represents a generic Function App trigger. With custom handlers many

--- a/trigger/generic_test.go
+++ b/trigger/generic_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/trigger/http.go
+++ b/trigger/http.go
@@ -156,6 +156,13 @@ func NewHTTP(r *http.Request, options ...HTTPOption) (*HTTP, error) {
 	}
 	d.Metadata = t.Metadata
 
+	canonicalHeaders := make(http.Header, len(d.Headers))
+	for k, v := range d.Headers {
+		canonicalHeaders[http.CanonicalHeaderKey(k)] = v
+	}
+
+	d.Headers = canonicalHeaders
+
 	return &d, nil
 }
 

--- a/trigger/http.go
+++ b/trigger/http.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 )
 
 var (
@@ -20,11 +20,9 @@ var (
 	ErrHTTPInvalidBody = errors.New("invalid body")
 )
 
-var (
-	// defaultMultipartFormMaxMemory is the default memory to use
-	// when parsing multipart form data.
-	defaultMultipartFormMaxMemory int64 = 32 << 20
-)
+// defaultMultipartFormMaxMemory is the default memory to use
+// when parsing multipart form data.
+var defaultMultipartFormMaxMemory int64 = 32 << 20
 
 // HTTP represents an HTTP trigger.
 type HTTP struct {

--- a/trigger/http_test.go
+++ b/trigger/http_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )

--- a/trigger/queue.go
+++ b/trigger/queue.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 )
 
 // Queue represents a Queue Storage trigger.

--- a/trigger/queue_test.go
+++ b/trigger/queue_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/trigger/service_bus.go
+++ b/trigger/service_bus.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 )
 
 // ServiceBus represents a Service Bus trigger. It supports both

--- a/trigger/service_bus_test.go
+++ b/trigger/service_bus_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/KarlGW/azfunc/data"
+	"github.com/potatoattack/azfunc/data"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/triggers.go
+++ b/triggers.go
@@ -3,7 +3,7 @@ package azfunc
 import (
 	"net/http"
 
-	"github.com/KarlGW/azfunc/trigger"
+	"github.com/potatoattack/azfunc/trigger"
 )
 
 // triggerable is the interface that wraps around the method run.


### PR DESCRIPTION
`http.Header` keys should be in [canonical form](https://pkg.go.dev/net/http?utm_source=godoc#Header) so that it's case insensitive and the methods (Get, Set, etc) work, instead of needing to manually index the map.

This change will break any code manually indexing the `http.Header` map (unless they keys were already in canonical form from the source) and will not show any errors or warnings at compile time.

A codebase can be checked for this error by installing `staticcheck` and running in the project root:
```bash
staticcheck -checks SA1008 ./...
```